### PR TITLE
Turn off log styling in trin

### DIFF
--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -5,4 +5,4 @@ set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
 
-RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000
+RUST_LOG_STYLE=never RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000


### PR DESCRIPTION
The "auto" styling doesn't detect that the logs will be displayed as plaintext, which looks ugly with styling characters, like:

	[2m2023-04-03T00:08:23.986956Z[0m [32m INFO[0m [2mtrin[0m[2m:[0m Launching Trin: v0.1.0-3c3462

So we turn off log styling manually, when running in hive. This is explained more in [env_logger docs about styling](https://docs.rs/env_logger/latest/env_logger/#disabling-colors).

See full example in https://portal-hive.ethdevops.io/viewer.html?file=results/trin/client-b3ac237fd44c3f2f98cb4fde10c07385c24869936a43a982bc4508eb261c8c31.log