### PR TITLE
Change to minor libssl version (1.1.0)

### DIFF
--- a/simulators/portal-interop/Dockerfile
+++ b/simulators/portal-interop/Dockerfile
@@ -16,8 +16,8 @@ FROM ubuntu:22.04
 
 RUN apt update && apt install wget -y
 
-RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 
 # copy build artifacts from build stage
 COPY --from=builder /portal-interop/target/release/portal-interop .

--- a/simulators/rpc-compat/Dockerfile
+++ b/simulators/rpc-compat/Dockerfile
@@ -16,8 +16,8 @@ FROM ubuntu:22.04
 
 RUN apt update && apt install wget -y
 
-RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 
 # copy build artifacts from build stage
 COPY --from=builder /rpc-compat/target/release/rpc-compat .


### PR DESCRIPTION
#### What was wrong?
The current libssl1 version is removed from the Ubuntu archive after a new version is released, which breaks the simulator containers.

#### How was it fixed?

Use a fixed minor libssl version (1.1.0)

