### PR TITLE
Add dockerfile libraries for arm machines

### DIFF
--- a/simulators/portal-interop/Dockerfile
+++ b/simulators/portal-interop/Dockerfile
@@ -16,8 +16,12 @@ FROM ubuntu:22.04
 
 RUN apt update && apt install wget -y
 
+# Use these for amd-based devices
 RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+# Use these for arm-based devices
+#RUN wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+#RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
 
 # copy build artifacts from build stage
 COPY --from=builder /portal-interop/target/release/portal-interop .

--- a/simulators/rpc-compat/Dockerfile
+++ b/simulators/rpc-compat/Dockerfile
@@ -16,8 +16,12 @@ FROM ubuntu:22.04
 
 RUN apt update && apt install wget -y
 
+# Use these for amd-based devices
 RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+# Use these for arm-based devices
+#RUN wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+#RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
 
 # copy build artifacts from build stage
 COPY --from=builder /rpc-compat/target/release/rpc-compat .


### PR DESCRIPTION
Running portal-hive is broken on arm-based machines (eg. my m1 mac). This is a bit of a hacky solution, but I'm not convinced an increasingly complex solution is justified in this scenario.