### PR TITLE
Added ``target`` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ workspace
 .idea/
 # build output
 /hive
+
+# don't include target files
+hivesim-rs/target
+simulators/*/target


### PR DESCRIPTION
Testing locally/developing new tests can be quite annoying since target files are flooding my changed files tracker.

Adding target to .gitignore should solve this