### PR TITLE
fix simulator cargo depends pulling hivesim from remote git

### DIFF
--- a/simulators/portal-interop/Cargo.toml
+++ b/simulators/portal-interop/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 ethportal-api = { git = "https://github.com/ethereum/trin" }
-hivesim = { git = "https://github.com/ogenev/portal-hive" }
+hivesim = { git = "https://github.com/ethereum/portal-hive" }
 itertools = "0.10.5"
 serde_json = "1.0.87"
 tokio = { version = "1", features = ["full"] }

--- a/simulators/rpc-compat/Cargo.toml
+++ b/simulators/rpc-compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 ethportal-api = { git = "https://github.com/ethereum/trin" }
-hivesim = { git = "https://github.com/ogenev/portal-hive" }
+hivesim = { git = "https://github.com/ethereum/portal-hive" }
 futures = "0.3.25"
 serde_json = "1.0.87"
 tracing = "0.1.37"


### PR DESCRIPTION
Currently the simulators hivesim depend is pulling from
``hivesim = { git = "https://github.com/ogenev/portal-hive" }``

This is making it hard to update/make changes to hivesim so I changed it to point the ethereum repo