### PR TITLE
Build simulators using local hivesim-rs instead of git

### DIFF
--- a/simulators/portal-interop/Cargo.lock
+++ b/simulators/portal-interop/Cargo.lock
@@ -1231,7 +1231,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hivesim"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/ogenev/portal-hive#0bad10ac0b0ad75ca71407752d5ea2fcc7263086"
+source = "git+https://github.com/ethereum/portal-hive#a40643672be5855e5e1ec623209a70f2b077a008"
 dependencies = [
  "async-trait",
  "dyn-clone",

--- a/simulators/portal-interop/Dockerfile
+++ b/simulators/portal-interop/Dockerfile
@@ -5,8 +5,9 @@ RUN USER=root cargo new --bin portal-interop
 WORKDIR /portal-interop
 
 # copy over manifests and source to build image
-COPY Cargo.toml ./Cargo.toml
-COPY src ./src
+COPY ./simulators/portal-interop/Cargo.toml ./Cargo.toml
+COPY ./simulators/portal-interop/src ./src
+COPY ./hivesim-rs ./../../hivesim-rs
 
 # build for release
 RUN cargo build --release

--- a/simulators/rpc-compat/Cargo.lock
+++ b/simulators/rpc-compat/Cargo.lock
@@ -1225,7 +1225,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hivesim"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/ogenev/portal-hive#0bad10ac0b0ad75ca71407752d5ea2fcc7263086"
+source = "git+https://github.com/ethereum/portal-hive#a40643672be5855e5e1ec623209a70f2b077a008"
 dependencies = [
  "async-trait",
  "dyn-clone",

--- a/simulators/rpc-compat/Dockerfile
+++ b/simulators/rpc-compat/Dockerfile
@@ -5,8 +5,9 @@ RUN USER=root cargo new --bin rpc-compat
 WORKDIR /rpc-compat
 
 # copy over manifests and source to build image
-COPY Cargo.toml ./Cargo.toml
-COPY src ./src
+COPY ./simulators/rpc-compat/Cargo.toml ./Cargo.toml
+COPY ./simulators/rpc-compat/src ./src
+COPY ./hivesim-rs ./../../hivesim-rs
 
 # build for release
 RUN cargo build --release


### PR DESCRIPTION
I made it so dockerfiles and the simulater Cargo.toml grab the local version of hivesim-rs which resolves a headache with CI if there are changes in both a simulater and hivesim-rs