### PR TITLE
portal-interop: Fix simulator panic

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -228,12 +228,19 @@ dyn_async! {
 
         let result = client_a.rpc.find_content(target_enr, header_with_proof_key.clone()).await;
 
-        match result.unwrap() {
-            ContentInfo::Content{ content: val } => {
-                assert_eq!(val, header_with_proof_value);
+        match result {
+            Ok(result) => {
+                match result {
+                    ContentInfo::Content{ content: val } => {
+                        assert_eq!(val, header_with_proof_value);
+                    },
+                    other => {
+                        test.fatal(&format!("Error: Unexpected FINDCONTENT response: {other:?}"));
+                    }
+                }
             },
-            _ => {
-                test.fatal(&format!("Error: Unable to get response from FINDCONTENT request"));
+            Err(err) => {
+                test.fatal(&format!("Error: Unable to get response from FINDCONTENT request: {err:?}"));
             }
         }
     }


### PR DESCRIPTION
Naked `unwrap` cause the main `portal-interop` sim thread to panic if the returned result is an error. 

This causes portal-hive to [exit](https://portal-hive.ethdevops.io/?page=v-pills-results-tab&suite=1687914820-2998714905ddb31599adc558de4cc11c.json) in the middle of executing the test suite because the Ultralight client returns a FindContent error.