### PR TITLE
Removed assert in FINDCONTENT immediate return test

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -184,7 +184,9 @@ dyn_async! {
             Ok(result) => {
                 match result {
                     ContentInfo::Content{ content: val } => {
-                        assert_eq!(val, header_with_proof_value);
+                        if val != header_with_proof_value {
+                            test.fatal("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
+                        }
                     },
                     other => {
                         test.fatal(&format!("Error: Unexpected FINDCONTENT response: {other:?}"));


### PR DESCRIPTION
I replaced this assert with by replacing it with throwing a test error if something goes wrong.

Asserts are bad because they panic the whole program and shouldn't be used for tests.