### PR TITLE
[Option A] Make fatal able to panic, preventing error log overridding

### DIFF
--- a/hivesim-rs/Cargo.lock
+++ b/hivesim-rs/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -679,6 +680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +751,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +815,29 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1025,6 +1069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1186,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1239,7 +1304,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",
@@ -1540,13 +1608,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1555,7 +1623,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1564,13 +1632,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1580,10 +1663,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1592,10 +1687,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1604,16 +1711,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/hivesim-rs/Cargo.toml
+++ b/hivesim-rs/Cargo.toml
@@ -12,3 +12,4 @@ jsonrpsee = {version="0.16.2", features = ["client"]}
 reqwest = { version = "0.11.12", features = ["json", "multipart"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
+tokio = { version = "1", features = ["full"] }

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -220,7 +220,6 @@ async fn run_client_test(
 
     test.lock().await.result.pass = true;
 
-    // run test function
     let client = test.lock().await.start_client(client_name).await;
 
     // run test function

--- a/simulators/portal-interop/Cargo.lock
+++ b/simulators/portal-interop/Cargo.lock
@@ -1312,6 +1312,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -7,6 +7,8 @@ use ethportal_api::{
 use hivesim::{dyn_async, Client, Simulation, Suite, Test, TestSpec, TwoClientTestSpec};
 use itertools::Itertools;
 use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio::time::Duration;
 
 // Header with proof for block number 14764013
@@ -165,26 +167,23 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return content via FINDCONTENT that it has stored locally
-    async fn test_find_content_immediate_return<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+    async fn test_find_content_immediate_return<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
         let header_with_proof_value: HistoryContentValue = serde_json::from_value(json!(HEADER_WITH_PROOF_VALUE)).unwrap();
 
         match client_b.rpc.store(header_with_proof_key.clone(), header_with_proof_value.clone()).await {
             Ok(result) => if !result {
-                test.fatal("Unable to store header with proof for find content immediate return test");
-                return;
+                test.lock().await.fatal("Unable to store header with proof for find content immediate return test");
             },
             Err(err) => {
-                test.fatal(&format!("Error storing header with proof for find content immediate return test: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error storing header with proof for find content immediate return test: {err:?}"));
             }
         }
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -196,16 +195,16 @@ dyn_async! {
                 match result {
                     ContentInfo::Content{ content: val } => {
                         if val != header_with_proof_value {
-                            test.fatal("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
+                            test.lock().await.fatal("Error: Unexpected FINDCONTENT response: didn't return expected header with proof value");
                         }
                     },
                     other => {
-                        test.fatal(&format!("Error: Unexpected FINDCONTENT response: {other:?}"));
+                        test.lock().await.fatal(&format!("Error: Unexpected FINDCONTENT response: {other:?}"));
                     }
                 }
             },
             Err(err) => {
-                test.fatal(&format!("Error: Unable to get response from FINDCONTENT request: {err:?}"));
+                test.lock().await.fatal(&format!("Error: Unable to get response from FINDCONTENT request: {err:?}"));
             }
         }
     }
@@ -213,14 +212,13 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will not return content via FINDCONTENT.
-    async fn test_find_content_non_present<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+    async fn test_find_content_non_present<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -228,21 +226,20 @@ dyn_async! {
         let result = client_a.rpc.find_content(target_enr, header_with_proof_key.clone()).await;
 
         if let Ok(ContentInfo::Content{ content: _ }) = result {
-            test.fatal("Error: Unexpected FINDCONTENT response: wasn't supposed to return back content");
+            test.lock().await.fatal("Error: Unexpected FINDCONTENT response: wasn't supposed to return back content");
         }
     }
 }
 
 dyn_async! {
-   async fn test_offer_header<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+   async fn test_offer_header<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
         let header_with_proof_value: HistoryContentValue = serde_json::from_value(json!(HEADER_WITH_PROOF_VALUE)).unwrap();
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -257,23 +254,23 @@ dyn_async! {
                match possible_content {
                     PossibleHistoryContentValue::ContentPresent(content) => {
                         if content != header_with_proof_value {
-                            test.fatal(&format!("Error receiving header with proof: Expected content: {header_with_proof_value:?}, Received content: {content:?}"));
+                            test.lock().await.fatal(&format!("Error receiving header with proof: Expected content: {header_with_proof_value:?}, Received content: {content:?}"));
                         }
                     }
                     PossibleHistoryContentValue::ContentAbsent => {
-                        test.fatal("Expected content not found!");
+                        test.lock().await.fatal("Expected content not found!");
                     }
                 }
             }
             Err(err) => {
-                test.fatal(&format!("Unable to get received content: {err:?}"));
+                test.lock().await.fatal(&format!("Unable to get received content: {err:?}"));
             }
         }
    }
 }
 
 dyn_async! {
-   async fn test_offer_header_shapella<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+   async fn test_offer_header_shapella<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let header_with_proof_shapella_key = "0x0017cf53189035bbae5bce5c844355badd701aa9d2dd4b4f5ab1f9f0e8dd9fea5b";
         let header_with_proof_shapella_value = "0x0800000039020000f9022ea0e22c56f211f03baadcc91e4eb9a24344e6848c5df4\
         473988f893b58223f5216ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940b70b578abd96aab5e80d24d1f\
@@ -291,8 +288,7 @@ dyn_async! {
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -307,23 +303,23 @@ dyn_async! {
                match possible_content {
                     PossibleHistoryContentValue::ContentPresent(content) => {
                         if content != header_with_proof_value {
-                            test.fatal(&format!("Error receiving Shapella header with proof: Expected content: {header_with_proof_value:?}, Received content: {content:?}"));
+                            test.lock().await.fatal(&format!("Error receiving Shapella header with proof: Expected content: {header_with_proof_value:?}, Received content: {content:?}"));
                         }
                     }
                     PossibleHistoryContentValue::ContentAbsent => {
-                        test.fatal("Expected content not found!");
+                        test.lock().await.fatal("Expected content not found!");
                     }
                 }
             }
             Err(err) => {
-                test.fatal(&format!("Unable to get received content: {err:?}"));
+                test.lock().await.fatal(&format!("Unable to get received content: {err:?}"));
             }
         }
    }
 }
 
 dyn_async! {
-   async fn test_offer_body<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+   async fn test_offer_body<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let block_body_key: HistoryContentKey = serde_json::from_value(json!(BLOCK_BODY_KEY)).unwrap();
         let block_body_value: HistoryContentValue = serde_json::from_value(json!(BLOCK_BODY_VALUE)).unwrap();
 
@@ -333,20 +329,17 @@ dyn_async! {
 
         match client_b.rpc.store(header_key.clone(), header_value.clone()).await {
             Ok(result) => if !result {
-                test.fatal("Unable to store header with proof for Block Body verification");
-                return;
+                test.lock().await.fatal("Unable to store header with proof for Block Body verification");
             },
             Err(err) => {
-                test.fatal(&format!("Error storing header with proof for Block Body verification: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error storing header with proof for Block Body verification: {err:?}"));
             }
         }
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -361,23 +354,23 @@ dyn_async! {
                match possible_content {
                     PossibleHistoryContentValue::ContentPresent(content) => {
                         if content != block_body_value {
-                            test.fatal(&format!("Error receiving block body: Expected content: {block_body_value:?}, Received content: {content:?}"));
+                            test.lock().await.fatal(&format!("Error receiving block body: Expected content: {block_body_value:?}, Received content: {content:?}"));
                         }
                     }
                     PossibleHistoryContentValue::ContentAbsent => {
-                        test.fatal("Expected content not found!");
+                        test.lock().await.fatal("Expected content not found!");
                     }
                 }
             }
             Err(err) => {
-                test.fatal(&format!("Unable to get received content: {err:?}"));
+                test.lock().await.fatal(&format!("Unable to get received content: {err:?}"));
             }
         }
    }
 }
 
 dyn_async! {
-   async fn test_offer_receipts<'a> (test: &'a mut Test, client_a: Client, client_b: Client) {
+   async fn test_offer_receipts<'a> (test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let receipts_key: HistoryContentKey = serde_json::from_value(json!(RECEIPTS_KEY)).unwrap();
         let receipts_value: HistoryContentValue = serde_json::from_value(json!(RECEIPTS_VALUE)).unwrap();
 
@@ -387,20 +380,17 @@ dyn_async! {
 
         match client_b.rpc.store(header_key.clone(), header_value.clone()).await {
             Ok(result) => if !result {
-                test.fatal("Error storing header with proof for Receipts verification");
-                return;
+                test.lock().await.fatal("Error storing header with proof for Receipts verification");
             },
             Err(err) => {
-                test.fatal(&format!("Error storing header with proof for Receipts verification: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error storing header with proof for Receipts verification: {err:?}"));
             }
         }
 
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
@@ -415,65 +405,63 @@ dyn_async! {
                match possible_content {
                     PossibleHistoryContentValue::ContentPresent(content) => {
                         if content != receipts_value {
-                            test.fatal(&format!("Error receiving block receipts: Expected content: {receipts_value:?}, Received content: {content:?}"));
+                            test.lock().await.fatal(&format!("Error receiving block receipts: Expected content: {receipts_value:?}, Received content: {content:?}"));
                         }
                     }
                     PossibleHistoryContentValue::ContentAbsent => {
-                        test.fatal("Expected content not found!");
+                        test.lock().await.fatal("Expected content not found!");
                     }
                 }
             }
             Err(err) => {
-                test.fatal(&format!("Unable to get received content: {err:?}"));
+                test.lock().await.fatal(&format!("Unable to get received content: {err:?}"));
             }
         }
    }
 }
 
 dyn_async! {
-    async fn test_ping<'a>(test: &'a mut Test, client_a: Client, client_b: Client) {
+    async fn test_ping<'a>(test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
         let pong = client_a.rpc.ping(target_enr).await;
 
         if let Err(err) = pong {
-                test.fatal(&format!("Unable to receive pong info: {err:?}"));
+                test.lock().await.fatal(&format!("Unable to receive pong info: {err:?}"));
         }
     }
 }
 
 dyn_async! {
-    async fn test_find_nodes_zero_distance<'a>(test: &'a mut Test, client_a: Client, client_b: Client) {
+    async fn test_find_nodes_zero_distance<'a>(test: Arc<Mutex<Test>>, client_a: Client, client_b: Client) {
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
-                test.fatal(&format!("Error getting node info: {err:?}"));
-                return;
+                test.lock().await.fatal(&format!("Error getting node info: {err:?}"));
             }
         };
 
         match client_a.rpc.find_nodes(target_enr.clone(), vec![0]).await {
             Ok(response) => {
                 if response.len() != 1 {
-                    test.fatal("Response from FindNodes didn't return expected length of 1");
+                    test.lock().await.fatal("Response from FindNodes didn't return expected length of 1");
                 }
 
                 match response.get(0) {
                     Some(response_enr) => {
                         if *response_enr != target_enr {
-                            test.fatal("Response from FindNodes didn't return expected Enr");
+                            test.lock().await.fatal("Response from FindNodes didn't return expected Enr");
                         }
                     },
-                    None => test.fatal("Error find nodes zero distance wasn't supposed to return None"),
+                    None => test.lock().await.fatal("Error find nodes zero distance wasn't supposed to return None"),
                 }
             }
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
     }
 }

--- a/simulators/rpc-compat/Cargo.lock
+++ b/simulators/rpc-compat/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/simulators/rpc-compat/src/main.rs
+++ b/simulators/rpc-compat/src/main.rs
@@ -4,6 +4,8 @@ use ethportal_api::HistoryNetworkApiClient;
 use ethportal_api::PossibleHistoryContentValue::{ContentAbsent, ContentPresent};
 use hivesim::{dyn_async, Client, ClientTestSpec, Simulation, Suite, Test, TestSpec};
 use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 // Header with proof for block number 14764013
 const CONTENT_KEY: &str = "0x00720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c";
@@ -139,19 +141,19 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_node_info<'a> (test: &'a mut Test, client: Client) {
+    async fn test_node_info<'a> (test: Arc<Mutex<Test>>, client: Client) {
        let response = client
             .rpc
             .node_info().await;
 
         if let Err(err) = response {
-            test.fatal(&format!("Expected response not received: {err}"));
+            test.lock().await.fatal(&format!("Expected response not received: {err}"));
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_absent<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_local_content_expect_content_absent<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let content_key =
         serde_json::from_value(json!(CONTENT_KEY));
 
@@ -165,23 +167,23 @@ dyn_async! {
                     Ok(response) => {
                         match response {
                             ContentAbsent => (),
-                            _ => test.fatal("Expected ContentAbsent, got ContentPresent")
+                            _ => test.lock().await.fatal("Expected ContentAbsent, got ContentPresent")
                         }
                     },
                     Err(err) => {
-                        test.fatal(&err.to_string());
+                        test.lock().await.fatal(&err.to_string());
                     },
                 }
             }
             Err(err) => {
-                test.fatal(&err.to_string());
+                test.lock().await.fatal(&err.to_string());
             }
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_store<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_store<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let content_key =
         serde_json::from_value(json!(CONTENT_KEY));
 
@@ -197,23 +199,23 @@ dyn_async! {
                             .store(content_key, content_value).await;
 
                         if let Err(err) = response {
-                            test.fatal(&err.to_string());
+                            test.lock().await.fatal(&err.to_string());
                         }
                     }
                     Err(err) => {
-                        test.fatal(&err.to_string());
+                        test.lock().await.fatal(&err.to_string());
                     }
                 }
             }
             Err(err) => {
-                test.fatal(&err.to_string());
+                test.lock().await.fatal(&err.to_string());
             }
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_local_content_expect_content_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let content_key: Result<ethportal_api::HistoryContentKey, serde_json::Error> =
         serde_json::from_value(json!(CONTENT_KEY));
 
@@ -231,11 +233,11 @@ dyn_async! {
                             .store(content_key.clone(), content_value).await;
 
                         if let Err(err) = response {
-                            test.fatal(&err.to_string());
+                            test.lock().await.fatal(&err.to_string());
                         }
                     }
                     Err(err) => {
-                        test.fatal(&err.to_string());
+                        test.lock().await.fatal(&err.to_string());
                     }
                 }
 
@@ -248,152 +250,152 @@ dyn_async! {
                     Ok(response) => {
                         match response {
                             ContentPresent(_) => (),
-                            _ => test.fatal("Expected ContentPresent, got ContentAbsent")
+                            _ => test.lock().await.fatal("Expected ContentPresent, got ContentAbsent")
                         }
                     },
                     Err(err) => {
-                        test.fatal(&err.to_string());
+                        test.lock().await.fatal(&err.to_string());
                     },
                 }
             }
             Err(err) => {
-                test.fatal(&err.to_string());
+                test.lock().await.fatal(&err.to_string());
             }
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_add_enr_expect_true<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_add_enr_expect_true<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr).await {
             Ok(response) => match response {
                 true => (),
-                false => test.fatal("AddEnr expected to get true and instead got false")
+                false => test.lock().await.fatal("AddEnr expected to get true and instead got false")
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_get_enr_non_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_get_enr_non_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
 
         if (HistoryNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await).is_ok() {
-            test.fatal("GetEnr in this case is not supposed to return a value")
+            test.lock().await.fatal("GetEnr in this case is not supposed to return a value")
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_get_enr_enr_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_get_enr_enr_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr.clone()).await {
             Ok(response) => match response {
                 true => (),
-                false => test.fatal("AddEnr expected to get true and instead got false")
+                false => test.lock().await.fatal("AddEnr expected to get true and instead got false")
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
 
         // check if we can fetch data from routing table
         match HistoryNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => {
                 if response != enr {
-                    test.fatal("Response from GetEnr didn't return expected Enr")
+                    test.lock().await.fatal("Response from GetEnr didn't return expected Enr")
                 }
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_non_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_delete_enr_non_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => match response {
-                true => test.fatal("DeleteEnr expected to get false and instead got true"),
+                true => test.lock().await.fatal("DeleteEnr expected to get false and instead got true"),
                 false => ()
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         };
     }
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_enr_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_delete_enr_enr_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr.clone()).await {
             Ok(response) => match response {
                 true => (),
-                false => test.fatal("AddEnr expected to get true and instead got false")
+                false => test.lock().await.fatal("AddEnr expected to get true and instead got false")
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
 
         // check if data was seeded into the table
         match HistoryNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => {
                 if response != enr {
-                    test.fatal("Response from GetEnr didn't return expected Enr")
+                    test.lock().await.fatal("Response from GetEnr didn't return expected Enr")
                 }
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
 
         // delete the data from routing table
         match HistoryNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => match response {
                 true => (),
-                false => test.fatal("DeleteEnr expected to get true and instead got false")
+                false => test.lock().await.fatal("DeleteEnr expected to get true and instead got false")
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         };
 
         // check if the enr was actually deleted out of the table or not
         if (HistoryNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await).is_ok() {
-            test.fatal("GetEnr in this case is not supposed to return a value")
+            test.lock().await.fatal("GetEnr in this case is not supposed to return a value")
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_non_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_lookup_enr_non_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
 
         if (HistoryNetworkApiClient::lookup_enr(&client.rpc, enr.node_id()).await).is_ok() {
-            test.fatal("LookupEnr in this case is not supposed to return a value")
+            test.lock().await.fatal("LookupEnr in this case is not supposed to return a value")
         }
     }
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_enr_present<'a>(test: &'a mut Test, client: Client) {
+    async fn test_history_lookup_enr_enr_present<'a>(test: Arc<Mutex<Test>>, client: Client) {
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr.clone()).await {
             Ok(response) => match response {
                 true => (),
-                false => test.fatal("AddEnr expected to get true and instead got false")
+                false => test.lock().await.fatal("AddEnr expected to get true and instead got false")
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
 
         // check if we can fetch data from routing table
         match HistoryNetworkApiClient::lookup_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => {
                 if response != enr {
-                    test.fatal("Response from LookupEnr didn't return expected Enr")
+                    test.lock().await.fatal("Response from LookupEnr didn't return expected Enr")
                 }
             },
-            Err(err) => test.fatal(&err.to_string()),
+            Err(err) => test.lock().await.fatal(&err.to_string()),
         }
     }
 }


### PR DESCRIPTION
Currently if someone writes a hivesim-rs test and report a failure with test.fatal() they can easily override the previous error which is bad practice. If fatal is called the test should be seen as done and not continue running.

Before this pr if you did
```
test.fatal("A");
test.fatal("B");
```
"B" would be the error in the test log

After this PR if the same example was ran as above instead this error will be there
``"Error: test overrides previous failure log, potential solution add return statement after 'test.fatal()' call"``

Adding this change prevents/warns us if a bad case like this ever occurs. The reason it is bad since most likely error A will be the cause of Error B, so it shouldn't be overridden. To list one argument for this change.

