### PR TITLE
Fix FindContent non-present to be strict with expected behavior

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -220,11 +220,28 @@ dyn_async! {
             }
         };
 
-
         let result = client_a.rpc.find_content(target_enr, header_with_proof_key.clone()).await;
 
         if let Ok(ContentInfo::Content{ content: _ }) = result {
             panic!("Error: Unexpected FINDCONTENT response: wasn't supposed to return back content");
+        }
+
+        match result {
+            Ok(result) => {
+                match result {
+                    ContentInfo::Enrs{ enrs: val } => {
+                        if !val.is_empty() {
+                            panic!("Error: Unexpected FINDCONTENT response: expected ContentInfo::Enrs length 0 got {}", val.len());
+                        }
+                    },
+                    other => {
+                        panic!("Error: Unexpected FINDCONTENT response: {other:?}");
+                    }
+                }
+            },
+            Err(err) => {
+                panic!("Error: Unable to get response from FINDCONTENT request: {err:?}");
+            }
         }
     }
 }


### PR DESCRIPTION
This tests are controlled and we want to make sure client are strictly conforming in expected behavior.

Both Kim and Nick told me this is the behavior we should expect (and empty enrs array)