### PR TITLE
Add back HIVE_ to CLIENT_PRIVATE_KEY which was removed in the reviews process of 3 client tests PR

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -5,9 +5,9 @@ set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
 
-# if CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${CLIENT_PRIVATE_KEY+x} ]; then
+# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
+if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug"
 else
-  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" --netkey-unsafe=${CLIENT_PRIVATE_KEY}
+  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" --netkey-unsafe=${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -5,9 +5,9 @@ set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
 
-# if CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${CLIENT_PRIVATE_KEY+x} ]; then
+# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
+if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none
 else
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none --unsafe-private-key ${CLIENT_PRIVATE_KEY}
+  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none --unsafe-private-key ${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/clients/ultralight/ultralight.sh
+++ b/clients/ultralight/ultralight.sh
@@ -5,9 +5,9 @@ set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
 
-# if CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${CLIENT_PRIVATE_KEY+x} ]; then
+# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
+if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545
 else
-  node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 --pk=${CLIENT_PRIVATE_KEY}
+  node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 --pk=${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -129,9 +129,10 @@ impl Simulation {
         let mut config = SimulatorConfig::new();
         config.client = client_type;
         if let Some(private_key) = private_key {
-            config
-                .environment
-                .insert("CLIENT_PRIVATE_KEY".to_string(), private_key.to_string());
+            config.environment.insert(
+                "HIVE_CLIENT_PRIVATE_KEY".to_string(),
+                private_key.to_string(),
+            );
         }
 
         let config = serde_json::to_string(&config).unwrap();


### PR DESCRIPTION
https://github.com/ethereum/portal-hive/pull/61#discussion_r1279123135

ogenev said the required ``HIVE_`` prefix was confusing. I forgot why I used it so I removed it from the PR and merged. When I checked portal hive tests my 3 client tests was failing the reason why? I remove HIVE_ from my enviroment variables cause I forgot the restriction existed. So in this PR I am adding the Prefix back