### PR TITLE
Add a test for recursive_find_content receipts over uTP

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -504,19 +504,19 @@ dyn_async! {
 
         match client_b.rpc.store(receipts_key.clone(), receipts_value.clone()).await {
             Ok(result) => if !result {
-                panic!("Error storing header with proof for Receipts verification");
+                panic!("Error storing receipts for recursive find content receipts over utp");
             },
             Err(err) => {
-                panic!("Error storing header with proof for Receipts verification: {err:?}");
+                panic!("Error storing receipts: {err:?}");
             }
         }
 
         match client_b.rpc.store(header_with_proof_key.clone(), header_with_proof_value.clone()).await {
             Ok(result) => if !result {
-                panic!("Unable to store header with proof for find content immediate return test");
+                panic!("Unable to store header with proof for recursive find content");
             },
             Err(err) => {
-                panic!("Error storing header with proof for find content immediate return test: {err:?}");
+                panic!("Error storing header with proof for recursive find content: {err:?}");
             }
         }
 

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -159,6 +159,18 @@ dyn_async! {
                     client_b: &(*client_b).clone(),
                 }
             ).await;
+
+            // Test find content receipts over uTP
+            test.run(
+                TwoClientTestSpec {
+                    name: format!("RECURSIVE_FIND_CONTENT Receipts over uTP {} --> {}", client_a.name, client_b.name),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_recursive_find_content_receipts_over_utp,
+                    client_a: &(*client_a).clone(),
+                    client_b: &(*client_b).clone(),
+                }
+            ).await;
         }
    }
 }
@@ -477,6 +489,70 @@ dyn_async! {
                 }
             }
             Err(err) => panic!("{}", &err.to_string()),
+        }
+    }
+}
+
+dyn_async! {
+    // test that a node will return a receipts via RECURSIVEFINDCONTENT over uTP that it has stored locally
+    async fn test_recursive_find_content_receipts_over_utp<'a> (client_a: Client, client_b: Client) {
+        let receipts_key: HistoryContentKey = serde_json::from_value(json!(RECEIPTS_KEY)).unwrap();
+        let receipts_value: HistoryContentValue = serde_json::from_value(json!(RECEIPTS_VALUE)).unwrap();
+
+        let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
+        let header_with_proof_value: HistoryContentValue = serde_json::from_value(json!(HEADER_WITH_PROOF_VALUE)).unwrap();
+
+        match client_b.rpc.store(receipts_key.clone(), receipts_value.clone()).await {
+            Ok(result) => if !result {
+                panic!("Error storing header with proof for Receipts verification");
+            },
+            Err(err) => {
+                panic!("Error storing header with proof for Receipts verification: {err:?}");
+            }
+        }
+
+        match client_b.rpc.store(header_with_proof_key.clone(), header_with_proof_value.clone()).await {
+            Ok(result) => if !result {
+                panic!("Unable to store header with proof for find content immediate return test");
+            },
+            Err(err) => {
+                panic!("Error storing header with proof for find content immediate return test: {err:?}");
+            }
+        }
+
+        let target_enr = match client_b.rpc.node_info().await {
+            Ok(node_info) => node_info.enr,
+            Err(err) => {
+                panic!("Error getting node info: {err:?}");
+            }
+        };
+
+        match HistoryNetworkApiClient::add_enr(&client_a.rpc, target_enr.clone()).await {
+            Ok(response) => match response {
+                true => (),
+                false => panic!("AddEnr expected to get true and instead got false")
+            },
+            Err(err) => panic!("{}", &err.to_string()),
+        }
+
+        match client_a.rpc.recursive_find_content(receipts_key.clone()).await {
+            Ok(result) => {
+                match result {
+                    // todo: when clients conform with spec we will need to add a check if
+                    // the uTP flag is true
+                    PossibleHistoryContentValue::ContentPresent( val ) => {
+                        if val != receipts_value {
+                            panic!("Error: Unexpected FINDCONTENT response: didn't return expected receipt");
+                        }
+                    },
+                    other => {
+                        panic!("Error: Unexpected FINDCONTENT response: {other:?}");
+                    }
+                }
+            },
+            Err(err) => {
+                panic!("Error: Unable to get response from FINDCONTENT request: {err:?}");
+            }
         }
     }
 }


### PR DESCRIPTION
Testing if uTP tranfers through recursive_find_content is implemented correctly