### PR TITLE
Copy over Cargo.lock files in docker builds

### DIFF
--- a/simulators/portal-interop/Dockerfile
+++ b/simulators/portal-interop/Dockerfile
@@ -5,6 +5,7 @@ RUN USER=root cargo new --bin portal-interop
 WORKDIR /portal-interop
 
 # copy over manifests and source to build image
+COPY ./simulators/portal-interop/Cargo.lock ./Cargo.lock
 COPY ./simulators/portal-interop/Cargo.toml ./Cargo.toml
 COPY ./simulators/portal-interop/src ./src
 COPY ./hivesim-rs ./../../hivesim-rs

--- a/simulators/portal-mesh/Dockerfile
+++ b/simulators/portal-mesh/Dockerfile
@@ -5,6 +5,7 @@ RUN USER=root cargo new --bin portal-mesh
 WORKDIR /portal-mesh
 
 # copy over manifests and source to build image
+COPY ./simulators/portal-mesh/Cargo.lock ./Cargo.lock
 COPY ./simulators/portal-mesh/Cargo.toml ./Cargo.toml
 COPY ./simulators/portal-mesh/src ./src
 COPY ./hivesim-rs ./../../hivesim-rs

--- a/simulators/rpc-compat/Dockerfile
+++ b/simulators/rpc-compat/Dockerfile
@@ -5,6 +5,7 @@ RUN USER=root cargo new --bin rpc-compat
 WORKDIR /rpc-compat
 
 # copy over manifests and source to build image
+COPY ./simulators/rpc-compat/Cargo.lock ./Cargo.lock
 COPY ./simulators/rpc-compat/Cargo.toml ./Cargo.toml
 COPY ./simulators/rpc-compat/src ./src
 COPY ./hivesim-rs ./../../hivesim-rs


### PR DESCRIPTION
This fixes a issue where when we update ethportal-api portal-hive will fail on us.

This will now require us to update ethportal-api in the lockfile if we want the new changes and prevent portal-hive randomly breaking. Since currently we pull the latest ethportal-api from git.