### PR TITLE
If start clients panics count it as a test fail instead of crashing test sutie

### DIFF
--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -121,7 +121,7 @@ impl Simulation {
         test_suite: SuiteID,
         test: TestID,
         client_type: String,
-        private_key: Option<&String>,
+        private_key: Option<String>,
     ) -> (String, IpAddr) {
         let url = format!("{}/testsuite/{}/test/{}/node", self.url, test_suite, test);
         let client = reqwest::Client::new();
@@ -129,10 +129,9 @@ impl Simulation {
         let mut config = SimulatorConfig::new();
         config.client = client_type;
         if let Some(private_key) = private_key {
-            config.environment.insert(
-                "HIVE_CLIENT_PRIVATE_KEY".to_string(),
-                private_key.to_string(),
-            );
+            config
+                .environment
+                .insert("HIVE_CLIENT_PRIVATE_KEY".to_string(), private_key);
         }
 
         let config = serde_json::to_string(&config).unwrap();

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -107,7 +107,7 @@ pub struct Test {
 }
 
 impl Test {
-    pub async fn start_client(&self, client_type: String, private_key: Option<&String>) -> Client {
+    pub async fn start_client(&self, client_type: String, private_key: Option<String>) -> Client {
         let (container, ip) = self
             .sim
             .start_client(
@@ -193,21 +193,21 @@ async fn run_client_test(
     let test_id = host.start_test(test.suite_id, test.name, test.desc).await;
     let suite_id = test.suite_id;
 
-    let mut test = &mut Test {
-        sim: host.clone(),
-        test_id,
-        suite: test.suite,
-        suite_id,
-        result: Default::default(),
-    };
-
-    test.result.pass = true;
-
-    let client = test.start_client(client_name, None).await;
-
     // run test function
+    let cloned_host = host.clone();
     let test_result = extract_test_results(
         tokio::spawn(async move {
+            let mut test = &mut Test {
+                sim: cloned_host,
+                test_id,
+                suite: test.suite,
+                suite_id,
+                result: Default::default(),
+            };
+
+            test.result.pass = true;
+
+            let client = test.start_client(client_name, None).await;
             (func)(client).await;
         })
         .await,
@@ -273,7 +273,7 @@ pub async fn run_test(
 }
 
 #[derive(Clone)]
-pub struct TwoClientTestSpec<'a> {
+pub struct TwoClientTestSpec {
     // These fields are displayed in the UI. Be sure to add
     // a meaningful description here.
     pub name: String,
@@ -284,12 +284,12 @@ pub struct TwoClientTestSpec<'a> {
     pub always_run: bool,
     // The Run function is invoked when the test executes.
     pub run: AsyncTwoClientsTestFunc,
-    pub client_a: &'a ClientDefinition,
-    pub client_b: &'a ClientDefinition,
+    pub client_a: ClientDefinition,
+    pub client_b: ClientDefinition,
 }
 
 #[async_trait]
-impl Testable for TwoClientTestSpec<'_> {
+impl Testable for TwoClientTestSpec {
     async fn run_test(&self, simulation: Simulation, suite_id: SuiteID, suite: Suite) {
         let test_run = TestRun {
             suite_id,
@@ -299,7 +299,14 @@ impl Testable for TwoClientTestSpec<'_> {
             always_run: self.always_run,
         };
 
-        run_two_client_test(simulation, test_run, self.client_a, self.client_b, self.run).await;
+        run_two_client_test(
+            simulation,
+            test_run,
+            self.client_a.to_owned(),
+            self.client_b.to_owned(),
+            self.run,
+        )
+        .await;
     }
 }
 
@@ -307,30 +314,30 @@ impl Testable for TwoClientTestSpec<'_> {
 async fn run_two_client_test(
     host: Simulation,
     test: TestRun,
-    client_a: &ClientDefinition,
-    client_b: &ClientDefinition,
+    client_a: ClientDefinition,
+    client_b: ClientDefinition,
     func: AsyncTwoClientsTestFunc,
 ) {
     // Register test on simulation server and initialize the T.
     let test_id = host.start_test(test.suite_id, test.name, test.desc).await;
     let suite_id = test.suite_id;
 
-    let mut test = &mut Test {
-        sim: host.clone(),
-        test_id,
-        suite: test.suite,
-        suite_id,
-        result: Default::default(),
-    };
-
-    test.result.pass = true;
-
-    let client_a = test.start_client(client_a.name.clone(), None).await;
-    let client_b = test.start_client(client_b.name.clone(), None).await;
-
     // run test function
+    let cloned_host = host.clone();
     let test_result = extract_test_results(
         tokio::spawn(async move {
+            let mut test = &mut Test {
+                sim: cloned_host,
+                test_id,
+                suite: test.suite,
+                suite_id,
+                result: Default::default(),
+            };
+
+            test.result.pass = true;
+
+            let client_a = test.start_client(client_a.name, None).await;
+            let client_b = test.start_client(client_b.name, None).await;
             (func)(client_a, client_b).await;
         })
         .await,
@@ -340,7 +347,7 @@ async fn run_two_client_test(
 }
 
 #[derive(Clone)]
-pub struct NClientTestSpec<'a> {
+pub struct NClientTestSpec {
     // These fields are displayed in the UI. Be sure to add
     // a meaningful description here.
     pub name: String,
@@ -354,12 +361,12 @@ pub struct NClientTestSpec<'a> {
     // length of private key array should match clients array
     // this attribute is optional and is used for tests which need node_ids relative to the
     // content within the test
-    pub private_keys: Option<&'a Vec<Option<&'a String>>>,
-    pub clients: &'a Vec<&'a ClientDefinition>,
+    pub private_keys: Option<Vec<Option<String>>>,
+    pub clients: Vec<ClientDefinition>,
 }
 
 #[async_trait]
-impl Testable for NClientTestSpec<'_> {
+impl Testable for NClientTestSpec {
     async fn run_test(&self, simulation: Simulation, suite_id: SuiteID, suite: Suite) {
         let test_run = TestRun {
             suite_id,
@@ -372,8 +379,8 @@ impl Testable for NClientTestSpec<'_> {
         run_n_client_test(
             simulation,
             test_run,
-            self.private_keys,
-            self.clients,
+            self.private_keys.to_owned(),
+            self.clients.to_owned(),
             self.run,
         )
         .await;
@@ -384,37 +391,37 @@ impl Testable for NClientTestSpec<'_> {
 async fn run_n_client_test(
     host: Simulation,
     test: TestRun,
-    private_keys: Option<&Vec<Option<&String>>>,
-    clients: &[&ClientDefinition],
+    private_keys: Option<Vec<Option<String>>>,
+    clients: Vec<ClientDefinition>,
     func: AsyncNClientsTestFunc,
 ) {
     // Register test on simulation server and initialize the T.
     let test_id = host.start_test(test.suite_id, test.name, test.desc).await;
     let suite_id = test.suite_id;
 
-    let mut test = &mut Test {
-        sim: host.clone(),
-        test_id,
-        suite: test.suite,
-        suite_id,
-        result: Default::default(),
-    };
-
-    test.result.pass = true;
-
-    let mut client_vec: Vec<Client> = Vec::new();
-    for (index, client) in clients.iter().enumerate() {
-        let private_key = if let Some(private_keys) = private_keys {
-            private_keys[index]
-        } else {
-            None
-        };
-        client_vec.push(test.start_client(client.name.clone(), private_key).await);
-    }
-
     // run test function
+    let cloned_host = host.clone();
     let test_result = extract_test_results(
         tokio::spawn(async move {
+            let mut test = &mut Test {
+                sim: cloned_host,
+                test_id,
+                suite: test.suite,
+                suite_id,
+                result: Default::default(),
+            };
+
+            test.result.pass = true;
+
+            let mut client_vec: Vec<Client> = Vec::new();
+            for (index, client) in clients.into_iter().enumerate() {
+                let private_key = if let Some(private_keys) = private_keys.clone() {
+                    private_keys[index].to_owned()
+                } else {
+                    None
+                };
+                client_vec.push(test.start_client(client.name.to_owned(), private_key).await);
+            }
             (func)(client_vec).await;
         })
         .await,

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -75,8 +75,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_offer_header,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -87,8 +87,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_offer_header_shapella,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -99,8 +99,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_offer_body,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -111,8 +111,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_offer_receipts,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -122,8 +122,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_ping,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -133,8 +133,8 @@ dyn_async! {
                     description: "find content: peer immediately returns locally available content".to_string(),
                     always_run: false,
                     run: test_find_content_immediate_return,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -144,8 +144,8 @@ dyn_async! {
                     description: "find content: calls find content that doesn't exist".to_string(),
                     always_run: false,
                     run: test_find_content_non_present,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -155,8 +155,8 @@ dyn_async! {
                     description: "find nodes: distance zero expect called nodes enr".to_string(),
                     always_run: false,
                     run: test_find_nodes_zero_distance,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -167,8 +167,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_recursive_find_content_receipts_over_utp,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
 
@@ -179,8 +179,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_receipts_over_utp,
-                    client_a: &(*client_a).clone(),
-                    client_b: &(*client_b).clone(),
+                    client_a: client_a.clone(),
+                    client_b: client_b.clone(),
                 }
             ).await;
         }

--- a/simulators/portal-mesh/src/main.rs
+++ b/simulators/portal-mesh/src/main.rs
@@ -66,8 +66,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_recipient_is_closer_to_content,
-                    private_keys: Some(&vec![None, Some(&private_key_2), Some(&private_key_1)]),
-                    clients: &vec![&(*client_a).clone(), &(*client_b).clone(), &(*client_c).clone()],
+                    private_keys: Some(vec![None, Some(private_key_2.clone()), Some(private_key_1.clone())]),
+                    clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
 
@@ -77,8 +77,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_recipient_knows_node_closer_to_content,
-                    private_keys: Some(&vec![None, Some(&private_key_1), Some(&private_key_2)]),
-                    clients: &vec![&(*client_a).clone(), &(*client_b).clone(), &(*client_c).clone()],
+                    private_keys: Some(vec![None, Some(private_key_1.clone()), Some(private_key_2.clone())]),
+                    clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
         }


### PR DESCRIPTION
Before if a client failed to start it would crash the test suite, now  instead the test fails and gives the error as the test failed error