### PR TITLE
Fix portal-mesh failing on ultralight privatekey format 

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -9,5 +9,5 @@ IP_ADDR=$(hostname -i | awk '{print $1}')
 if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug"
 else
-  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" --netkey-unsafe=${HIVE_CLIENT_PRIVATE_KEY}
+  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" --netkey-unsafe=0x${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -9,5 +9,5 @@ IP_ADDR=$(hostname -i | awk '{print $1}')
 if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none
 else
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none --unsafe-private-key ${HIVE_CLIENT_PRIVATE_KEY}
+  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none --unsafe-private-key 0x${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/clients/ultralight/ultralight.sh
+++ b/clients/ultralight/ultralight.sh
@@ -9,5 +9,5 @@ IP_ADDR=$(hostname -i | awk '{print $1}')
 if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
   node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545
 else
-  node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 --pk=${HIVE_CLIENT_PRIVATE_KEY}
+  node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 --pk=0x1a2408021220${HIVE_CLIENT_PRIVATE_KEY}
 fi

--- a/simulators/portal-mesh/src/main.rs
+++ b/simulators/portal-mesh/src/main.rs
@@ -53,8 +53,8 @@ dyn_async! {
         // Get all available portal clients
         let clients = test.sim.client_types().await;
 
-        let private_key_1 = "0xfc34e57cc83ed45aae140152fd84e2c21d1f4d46e19452e13acc7ee90daa5bac".to_string();
-        let private_key_2 = "0xe5add57dc4c9ef382509e61ce106ec86f60eb73bbfe326b00f54bf8e1819ba11".to_string();
+        let private_key_1 = "fc34e57cc83ed45aae140152fd84e2c21d1f4d46e19452e13acc7ee90daa5bac".to_string();
+        let private_key_2 = "e5add57dc4c9ef382509e61ce106ec86f60eb73bbfe326b00f54bf8e1819ba11".to_string();
 
         // Iterate over all possible pairings of clients and run the tests (including self-pairings)
         for ((client_a, client_b), client_c) in clients.iter().cartesian_product(clients.iter()).cartesian_product(clients.iter()) {


### PR DESCRIPTION
ultralight for importing privatekeys uses this 0x1a2408021220 prefix it is a protobuf thing, now ultralight works for portal-mesh.