### PR TITLE
Refactor tests which relied on restriction on closeness of nodes returned on FindContent because of spec change

### DIFF
--- a/simulators/portal-mesh/src/main.rs
+++ b/simulators/portal-mesh/src/main.rs
@@ -53,31 +53,15 @@ dyn_async! {
         // Get all available portal clients
         let clients = test.sim.client_types().await;
 
-        let private_key_1 = "fc34e57cc83ed45aae140152fd84e2c21d1f4d46e19452e13acc7ee90daa5bac".to_string();
-        let private_key_2 = "e5add57dc4c9ef382509e61ce106ec86f60eb73bbfe326b00f54bf8e1819ba11".to_string();
-
         // Iterate over all possible pairings of clients and run the tests (including self-pairings)
         for ((client_a, client_b), client_c) in clients.iter().cartesian_product(clients.iter()).cartesian_product(clients.iter()) {
-
-            // Test block header with proof
             test.run(
                 NClientTestSpec {
-                    name: format!("FIND_CONTENT A gets 0 ENRs, if B is closer to content than C. A:{} --> B:{} --> C:{}", client_a.name, client_b.name, client_c.name),
+                    name: format!("FIND_CONTENT content stored 2 nodes away stored in client C. A:{} --> B:{} --> C:{}", client_a.name, client_b.name, client_c.name),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_find_content_recipient_is_closer_to_content,
-                    private_keys: Some(vec![None, Some(private_key_2.clone()), Some(private_key_1.clone())]),
-                    clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
-                }
-            ).await;
-
-            test.run(
-                NClientTestSpec {
-                    name: format!("FIND_CONTENT A gets ENR for C, if B is further from content than C. A:{} --> B:{} --> C:{}", client_a.name, client_b.name, client_c.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_recipient_knows_node_closer_to_content,
-                    private_keys: Some(vec![None, Some(private_key_1.clone()), Some(private_key_2.clone())]),
+                    run: test_find_content_two_jumps,
+                    private_keys: None,
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -86,64 +70,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_content_recipient_is_closer_to_content<'a> (clients: Vec<Client>) {
-        let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
-            Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
-            None => {
-                panic!("Unable to get expected amount of clients from NClientTestSpec");
-            }
-        };
-
-        let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
-
-        // get enr for b and c to seed for the jumps
-        let client_b_enr = match client_b.rpc.node_info().await {
-            Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
-        };
-
-        let client_c_enr = match client_c.rpc.node_info().await {
-            Ok(node_info) => node_info.enr,
-            Err(err) => {
-                panic!("Error getting node info: {err:?}");
-            }
-        };
-
-        // seed client_c_enr into routing table of client_b
-        match HistoryNetworkApiClient::add_enr(&client_b.rpc, client_c_enr.clone()).await {
-            Ok(response) => match response {
-                true => (),
-                false => panic!("AddEnr expected to get true and instead got false")
-            },
-            Err(err) => panic!("{}", &err.to_string()),
-        }
-
-        let enrs = match client_a.rpc.find_content(client_b_enr.clone(), header_with_proof_key.clone()).await {
-            Ok(result) => {
-                match result {
-                    ContentInfo::Enrs{ enrs } => {
-                        enrs
-                    },
-                    other => {
-                        panic!("Error: (Enrs) Unexpected FINDCONTENT response not: {other:?}");
-                    }
-                }
-            },
-            Err(err) => {
-                panic!("Error: (Enrs) Unable to get response from FINDCONTENT request: {err:?}");
-            }
-        };
-
-        if !enrs.is_empty() {
-            panic!("Because content XOR node B is less then content XOR node C, A should get 0 enrs, but got: length {}", enrs.len());
-        }
-    }
-}
-
-dyn_async! {
-    async fn test_find_content_recipient_knows_node_closer_to_content<'a> (clients: Vec<Client>) {
+    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {
@@ -169,6 +96,7 @@ dyn_async! {
             }
         };
 
+
         // seed client_c_enr into routing table of client_b
         match HistoryNetworkApiClient::add_enr(&client_b.rpc, client_c_enr.clone()).await {
             Ok(response) => match response {
@@ -176,6 +104,11 @@ dyn_async! {
                 false => panic!("AddEnr expected to get true and instead got false")
             },
             Err(err) => panic!("{}", &err.to_string()),
+        }
+
+        // send a ping from client B to C to connect the clients
+        if let Err(err) = client_b.rpc.ping(client_c_enr.clone()).await {
+                panic!("Unable to receive pong info: {err:?}");
         }
 
         // seed the data into client_c


### PR DESCRIPTION
**blocked till https://github.com/ethereum/portal-network-specs/pull/222 is merged**

### What was wrong?
There is a update to the spec where we no longer ``list of ENR records of nodes that are closer than the recipient is to the requested content.`` and instead do ``list of ENR records of nodes that are closest to the requested content.``
### How was it fixed?
By consolidating the tests which used to be branches into one, since the possible branch based off a clients node_id to the content is no longer a thing