### PR TITLE
Network-n-client-test

### DIFF
--- a/hivesim-ts/src/testapi.ts
+++ b/hivesim-ts/src/testapi.ts
@@ -321,7 +321,10 @@ export class NClientTestSpec implements Testable {
     this.run = opts.run
   }
   async run_test(simulation: Simulation, suite_id: SuiteID, suite: Suite) {
-    const clients = await simulation.client_types()
+    let clients = await simulation.client_types()
+    if (clients.length === 1) {
+      clients = [clients[0], clients[0]]
+    }
     const clientNames = clients.map((client) => client.name)
     const test_run: ITestRun = {
       suite_id,


### PR DESCRIPTION
Updates the `hivesim-ts`

Adds a new variety of test: `Network_N_Client_Test`.

This type of test will test each client individually in networks of different sizes.
The network will be a mix of the clients types passed to the hivesim in the command line


For example, a suite for `getBlockByHash` might look like:
> ./hive --sim getBlockByHash --client fluffy,trin,ultralight

```
+ getBlockByHash --> fluffy (network size: 4)
+ getBlockByHash --> trin (network size: 4)
+ getBlockByHash --> ultralight (network size: 4)
+ getBlockByHash --> fluffy (network size: 10)
+ getBlockByHash --> trin (network size: 10)
+ getBlockByHash --> ultralight (network size: 10)
```


* This PR also fixes an issue with handling only one client type in the multiple clients test in `hivesim-ts` 