### PR TITLE
Run add_enr for each RFC test and remove pings

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -593,7 +593,7 @@ dyn_async! {
                 true => (),
                 false => panic!("AddEnr expected to get true and instead got false")
             },
-            Err(err) => panic!("{}", &err.to_string()),
+            Err(err) => panic!("Failed while trying to add client B's ENR to client A: {err}"),
         }
 
         match client_a.rpc.recursive_find_content(block_body_key.clone()).await {

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -708,9 +708,8 @@ dyn_async! {
         };
 
         match HistoryNetworkApiClient::add_enr(&client_a.rpc, target_enr.clone()).await {
-            Ok(response) => match response {
-                true => (),
-                false => panic!("AddEnr expected to get true and instead got false")
+            Ok(response) => if !response {
+                panic!("AddEnr expected to get true and instead got false")
             },
             Err(err) => panic!("{}", &err.to_string()),
         }

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -589,9 +589,8 @@ dyn_async! {
         };
 
         match HistoryNetworkApiClient::add_enr(&client_a.rpc, target_enr.clone()).await {
-            Ok(response) => match response {
-                true => (),
-                false => panic!("AddEnr expected to get true and instead got false")
+            Ok(response) => if !response {
+                panic!("AddEnr expected to get true and instead got false")
             },
             Err(err) => panic!("Failed while trying to add client B's ENR to client A: {err}"),
         }

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -588,9 +588,12 @@ dyn_async! {
             }
         };
 
-        // send a ping so client A sees it as a seen/connected node
-        if let Err(err) = client_a.rpc.ping(target_enr.clone()).await {
-                panic!("Unable to receive pong info: {err:?}");
+        match HistoryNetworkApiClient::add_enr(&client_a.rpc, target_enr.clone()).await {
+            Ok(response) => match response {
+                true => (),
+                false => panic!("AddEnr expected to get true and instead got false")
+            },
+            Err(err) => panic!("{}", &err.to_string()),
         }
 
         match client_a.rpc.recursive_find_content(block_body_key.clone()).await {
@@ -659,11 +662,6 @@ dyn_async! {
             Err(err) => panic!("{}", &err.to_string()),
         }
 
-        // send a ping so client A sees it as a seen/connected node
-        if let Err(err) = client_a.rpc.ping(target_enr.clone()).await {
-                panic!("Unable to receive pong info: {err:?}");
-        }
-
         match client_a.rpc.recursive_find_content(receipts_key.clone()).await {
             Ok(result) => {
                 match result {
@@ -710,9 +708,12 @@ dyn_async! {
             }
         };
 
-        // send a ping so client A sees it as a seen/connected node
-        if let Err(err) = client_a.rpc.ping(target_enr.clone()).await {
-                panic!("Unable to receive pong info: {err:?}");
+        match HistoryNetworkApiClient::add_enr(&client_a.rpc, target_enr.clone()).await {
+            Ok(response) => match response {
+                true => (),
+                false => panic!("AddEnr expected to get true and instead got false")
+            },
+            Err(err) => panic!("{}", &err.to_string()),
         }
 
         match client_a.rpc.recursive_find_content(header_with_proof_key.clone()).await {


### PR DESCRIPTION
Add_enr is better specified for each ENR than what a ping does, it should be also faster for this test, which its purpose is not testing the pings.