### PR TITLE
Add check if ENR got stored in ping/pong test

### DIFF
--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -535,7 +535,7 @@ dyn_async! {
         match HistoryNetworkApiClient::get_enr(&client_b.rpc, stored_enr.node_id()).await {
             Ok(response) => {
                 if response != stored_enr {
-                    panic!("Response from GetEnr didn't return expected ENR")
+                    panic!("Response from GetEnr didn't return expected ENR. Got: {response}; Expected: {stored_enr}")
                 }
             },
             Err(err) => panic!("Failed while trying to get client A's ENR from client B: {err}"),

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -522,6 +522,24 @@ dyn_async! {
         if let Err(err) = pong {
                 panic!("Unable to receive pong info: {err:?}");
         }
+
+        // Verify that client_b stored client_a its ENR through the base layer
+        // handshake mechanism.
+        let stored_enr = match client_a.rpc.node_info().await {
+            Ok(node_info) => node_info.enr,
+            Err(err) => {
+                panic!("Error getting node info: {err:?}");
+            }
+        };
+
+        match HistoryNetworkApiClient::get_enr(&client_b.rpc, stored_enr.node_id()).await {
+            Ok(response) => {
+                if response != stored_enr {
+                    panic!("Response from GetEnr didn't return expected ENR")
+                }
+            },
+            Err(err) => panic!("Failed while trying to get client A's ENR from client B: {err}"),
+        }
     }
 }
 


### PR DESCRIPTION
Test the scenario where client B stored client A's ENR on a first message interaction through the base layer (discv5) handshake.

By adding this test, and by using add_enr in https://github.com/ethereum/portal-hive/pull/94, we separate more properly what we are actually testing in these different test cases.