### PR TITLE
Make simulators Dockerfiles arch agnostic

### DIFF
--- a/simulators/portal-interop/Dockerfile
+++ b/simulators/portal-interop/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.2 AS builder
+FROM rust:1.68.2-bullseye AS builder
 
 # create a new empty shell project
 RUN USER=root cargo new --bin portal-interop
@@ -14,16 +14,7 @@ COPY ./hivesim-rs ./../../hivesim-rs
 RUN cargo build --release
 
 # final base
-FROM ubuntu:22.04
-
-RUN apt update && apt install wget -y
-
-# Use these for amd-based devices
-RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-# Use these for arm-based devices
-#RUN wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-#RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+FROM debian:bullseye-slim
 
 # copy build artifacts from build stage
 COPY --from=builder /portal-interop/target/release/portal-interop .

--- a/simulators/portal-mesh/Dockerfile
+++ b/simulators/portal-mesh/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.2 AS builder
+FROM rust:1.68.2-bullseye AS builder
 
 # create a new empty shell project
 RUN USER=root cargo new --bin portal-mesh
@@ -14,16 +14,7 @@ COPY ./hivesim-rs ./../../hivesim-rs
 RUN cargo build --release
 
 # final base
-FROM ubuntu:22.04
-
-RUN apt update && apt install wget -y
-
-# Use these for amd-based devices
-RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-# Use these for arm-based devices
-#RUN wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-#RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+FROM debian:bullseye-slim
 
 # copy build artifacts from build stage
 COPY --from=builder /portal-mesh/target/release/portal-mesh .

--- a/simulators/rpc-compat/Dockerfile
+++ b/simulators/rpc-compat/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.2 AS builder
+FROM rust:1.68.2-bullseye AS builder
 
 # create a new empty shell project
 RUN USER=root cargo new --bin rpc-compat
@@ -14,16 +14,7 @@ COPY ./hivesim-rs ./../../hivesim-rs
 RUN cargo build --release
 
 # final base
-FROM ubuntu:22.04
-
-RUN apt update && apt install wget -y
-
-# Use these for amd-based devices
-RUN wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
-# Use these for arm-based devices
-#RUN wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-#RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+FROM debian:bullseye-slim
 
 # copy build artifacts from build stage
 COPY --from=builder /rpc-compat/target/release/rpc-compat .


### PR DESCRIPTION
I've got stuck trying to run simulators. @kdeme quickly helped me, but I think we can do better than commenting/uncommetings lines.
`aarch64->arm64` needed because some systems report `aarch64` and some `arm64` while ubuntu only uses `arm64` as an architecture name.