### PR TITLE
Update Ultralight to use docker image

### DIFF
--- a/clients/ultralight/Dockerfile
+++ b/clients/ultralight/Dockerfile
@@ -1,17 +1,5 @@
-FROM node:18-alpine
+FROM ghcr.io/acolytec3/ultralight:latest
 
-RUN apk update && apk add --no-cache bash g++ make git python3 && rm -rf /var/cache/apk/*
-
-RUN git clone --depth 1 https://github.com/ethereumjs/ultralight.git 
-
-WORKDIR /ultralight
-
-RUN npm i --omit-dev
-
-COPY . .
-
-
-WORKDIR /
 COPY ultralight.sh /ultralight.sh
 RUN chmod +x /ultralight.sh
 

--- a/clients/ultralight/Dockerfile
+++ b/clients/ultralight/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/acolytec3/ultralight:latest
+FROM ghcr.io/ethereumjs/ultralight:latest
 
 COPY ultralight.sh /ultralight.sh
 RUN chmod +x /ultralight.sh


### PR DESCRIPTION
This updates the Ultralight client to use a nightly built docker image instead of building from source every time.