### PR TITLE
feat: make tests auto generate from file and fully support env variables

### DIFF
--- a/hivesim-rs/src/simulation.rs
+++ b/hivesim-rs/src/simulation.rs
@@ -131,17 +131,15 @@ impl Simulation {
         test_suite: SuiteID,
         test: TestID,
         client_type: String,
-        private_key: Option<String>,
+        environment: Option<HashMap<String, String>>,
     ) -> (String, IpAddr) {
         let url = format!("{}/testsuite/{}/test/{}/node", self.url, test_suite, test);
         let client = reqwest::Client::new();
 
         let mut config = SimulatorConfig::new();
         config.client = client_type;
-        if let Some(private_key) = private_key {
-            config
-                .environment
-                .insert("HIVE_CLIENT_PRIVATE_KEY".to_string(), private_key);
+        if let Some(environment) = environment {
+            config.environment = environment;
         }
 
         let config = serde_json::to_string(&config).expect("Failed to parse config to serde_json");

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use core::fmt::Debug;
 use dyn_clone::DynClone;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use std::collections::HashMap;
 use std::net::IpAddr;
 
 use crate::utils::{client_test_name, extract_test_results};
@@ -43,6 +44,7 @@ pub type AsyncTwoClientsTestFunc = fn(
 
 pub type AsyncNClientsTestFunc = fn(
     Vec<Client>,
+    Option<Vec<(String, String)>>,
 ) -> Pin<
     Box<
         dyn Future<Output = ()> // future API / pollable
@@ -107,14 +109,18 @@ pub struct Test {
 }
 
 impl Test {
-    pub async fn start_client(&self, client_type: String, private_key: Option<String>) -> Client {
+    pub async fn start_client(
+        &self,
+        client_type: String,
+        environment: Option<HashMap<String, String>>,
+    ) -> Client {
         let (container, ip) = self
             .sim
             .start_client(
                 self.suite_id,
                 self.test_id,
                 client_type.clone(),
-                private_key,
+                environment,
             )
             .await;
 
@@ -360,11 +366,11 @@ pub struct NClientTestSpec {
     pub always_run: bool,
     // The Run function is invoked when the test executes.
     pub run: AsyncNClientsTestFunc,
-    // length of private key array should match clients array
-    // this attribute is optional and is used for tests which need node_ids relative to the
-    // content within the test
-    pub private_keys: Option<Vec<Option<String>>>,
+    // a hashmap of Hive Environment Variables
+    pub environment: Option<Vec<Option<HashMap<String, String>>>>,
+    pub test_data: Option<Vec<(String, String)>>,
     pub clients: Vec<ClientDefinition>,
+    // test data which can be passed to the test
 }
 
 #[async_trait]
@@ -381,7 +387,8 @@ impl Testable for NClientTestSpec {
         run_n_client_test(
             simulation,
             test_run,
-            self.private_keys.to_owned(),
+            self.test_data.to_owned(),
+            self.environment.to_owned(),
             self.clients.to_owned(),
             self.run,
         )
@@ -393,7 +400,8 @@ impl Testable for NClientTestSpec {
 async fn run_n_client_test(
     host: Simulation,
     test: TestRun,
-    private_keys: Option<Vec<Option<String>>>,
+    test_data: Option<Vec<(String, String)>>,
+    environment: Option<Vec<Option<HashMap<String, String>>>>,
     clients: Vec<ClientDefinition>,
     func: AsyncNClientsTestFunc,
 ) {
@@ -417,14 +425,17 @@ async fn run_n_client_test(
 
             let mut client_vec: Vec<Client> = Vec::new();
             for (index, client) in clients.into_iter().enumerate() {
-                let private_key = if let Some(private_keys) = private_keys.clone() {
-                    private_keys[index].to_owned()
+                let environment_variable = if let Some(environment_variable) = environment.clone() {
+                    environment_variable[index].to_owned()
                 } else {
                     None
                 };
-                client_vec.push(test.start_client(client.name.to_owned(), private_key).await);
+                client_vec.push(
+                    test.start_client(client.name.to_owned(), environment_variable)
+                        .await,
+                );
             }
-            (func)(client_vec).await;
+            (func)(client_vec, test_data).await;
         })
         .await,
     );

--- a/simulators/portal-interop/src/main.rs
+++ b/simulators/portal-interop/src/main.rs
@@ -1,9 +1,12 @@
 use ethportal_api::types::portal::ContentInfo;
+use ethportal_api::utils::bytes::hex_encode;
 use ethportal_api::{
     ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
-    PossibleHistoryContentValue,
+    OverlayContentKey, PossibleHistoryContentValue,
 };
-use hivesim::{dyn_async, Client, Simulation, Suite, Test, TestSpec, TwoClientTestSpec};
+use hivesim::{
+    dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec, TwoClientTestSpec,
+};
 use itertools::Itertools;
 use serde_json::json;
 use serde_yaml::Value;
@@ -54,155 +57,124 @@ async fn run_suite(host: Simulation, suite: Suite) {
     host.end_suite(suite_id).await;
 }
 
+fn content_pair_to_string_pair(
+    content_pair: (HistoryContentKey, HistoryContentValue),
+) -> (String, String) {
+    let (content_key, content_value) = content_pair;
+    (content_key.to_hex(), hex_encode(content_value.encode()))
+}
+
+struct ProcessedContent {
+    content_type: String,
+    block_number: u64,
+    test_data: Vec<(String, String)>,
+}
+
+fn process_content(
+    content: Vec<(HistoryContentKey, HistoryContentValue)>,
+) -> Vec<ProcessedContent> {
+    let mut last_header = content.get(0).unwrap().clone();
+
+    let mut result: Vec<ProcessedContent> = vec![];
+    for history_content in content.into_iter() {
+        if let HistoryContentKey::BlockHeaderWithProof(_) = &history_content.0 {
+            last_header = history_content.clone();
+        }
+        let (content_type, block_number, test_data) =
+            if let HistoryContentValue::BlockHeaderWithProof(header_with_proof) = &last_header.1 {
+                match &history_content.0 {
+                    HistoryContentKey::BlockHeaderWithProof(_) => (
+                        "Block Header".to_string(),
+                        header_with_proof.header.number,
+                        vec![content_pair_to_string_pair(last_header.clone())],
+                    ),
+                    HistoryContentKey::BlockBody(_) => (
+                        "Block Body".to_string(),
+                        header_with_proof.header.number,
+                        vec![
+                            content_pair_to_string_pair(last_header.clone()),
+                            content_pair_to_string_pair(history_content),
+                        ],
+                    ),
+                    HistoryContentKey::BlockReceipts(_) => (
+                        "Block Receipt".to_string(),
+                        header_with_proof.header.number,
+                        vec![
+                            content_pair_to_string_pair(last_header.clone()),
+                            content_pair_to_string_pair(history_content),
+                        ],
+                    ),
+                    HistoryContentKey::EpochAccumulator(_) => (
+                        "Epoch Accumulator".to_string(),
+                        header_with_proof.header.number,
+                        vec![],
+                    ),
+                }
+            } else {
+                unreachable!("History test dated is formatted incorrectly")
+            };
+        result.push(ProcessedContent {
+            content_type,
+            block_number,
+            test_data,
+        })
+    }
+    result
+}
+
+fn get_flair(block_number: u64) -> String {
+    if block_number > 17034870 {
+        " (post-shanghai)".to_string()
+    } else if block_number > 15537394 {
+        " (post-merge)".to_string()
+    } else if block_number > 12965000 {
+        " (post-london)".to_string()
+    } else if block_number > 12244000 {
+        " (post-berlin)".to_string()
+    } else if block_number > 9069000 {
+        " (post-istanbul)".to_string()
+    } else if block_number > 7280000 {
+        " (post-constantinople)".to_string()
+    } else if block_number > 4370000 {
+        " (post-byzantium)".to_string()
+    } else if block_number > 1150000 {
+        " (post-homestead)".to_string()
+    } else {
+        "".to_string()
+    }
+}
+
 dyn_async! {
    async fn test_portal_interop<'a> (test: &'a mut Test, _client: Option<Client>) {
         // Get all available portal clients
         let clients = test.sim.client_types().await;
 
+        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
+            .expect("cannot find test asset");
+        let values: Value = serde_yaml::from_str(&values).unwrap();
+        let content: Vec<(HistoryContentKey, HistoryContentValue)> = values.as_sequence().unwrap().iter().map(|value| {
+            let header_key: HistoryContentKey =
+                serde_yaml::from_value(value.get("content_key").unwrap().clone()).unwrap();
+            let header_value: HistoryContentValue =
+                serde_yaml::from_value(value.get("content_value").unwrap().clone()).unwrap();
+            (header_key, header_value)
+        }).collect();
+
         // Iterate over all possible pairings of clients and run the tests (including self-pairings)
         for (client_a, client_b) in clients.iter().cartesian_product(clients.iter()) {
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Header: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_header_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Header: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_header_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Header: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_header_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Header: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_header_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Header: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_header_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Body: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_block_body_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Body: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_block_body_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Body: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_block_body_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Body: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_block_body_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Block Body: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_block_body_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Receipts: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_receipts_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Receipts: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_receipts_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("OFFER Receipts: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_offer_receipts_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
+            for ProcessedContent { content_type, block_number, test_data } in process_content(content.clone()) {
+                test.run(
+                    NClientTestSpec {
+                        name: format!("OFFER {}: block number {}{} {} --> {}", content_type, block_number, get_flair(block_number), client_a.name, client_b.name),
+                        description: "".to_string(),
+                        always_run: false,
+                        run: test_offer_x,
+                        environment: None,
+                        test_data: Some(test_data),
+                        clients: vec![client_a.clone(), client_b.clone()],
+                    }
+                ).await;
+            }
 
             // Test portal history ping
             test.run(TwoClientTestSpec {
@@ -237,327 +209,44 @@ dyn_async! {
                 }
             ).await;
 
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Header: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_header_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
+            for ProcessedContent { content_type, block_number, test_data } in process_content(content.clone()) {
+                test.run(
+                    NClientTestSpec {
+                        name: format!("RecursiveFindContent {}: block number {}{} {} --> {}", content_type, block_number, get_flair(block_number), client_a.name, client_b.name),
+                        description: "".to_string(),
+                        always_run: false,
+                        run: test_recursive_find_content_x,
+                        environment: None,
+                        test_data: Some(test_data),
+                        clients: vec![client_a.clone(), client_b.clone()],
+                    }
+                ).await;
+            }
 
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Header: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_header_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Header: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_header_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Header: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_header_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Header: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_header_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Body: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_block_body_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Body: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_block_body_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Body: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_block_body_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Body: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_block_body_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Block Body: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_block_body_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Receipts: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_receipts_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Receipts: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_receipts_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test recursive find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("RecursiveFindContent Receipts: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_recursive_find_content_receipts_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Header: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_header_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Header: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_header_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Header: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_header_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Header: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_header_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Header: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_header_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Body: block number 1 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_block_body_block_1,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Body: block number 100 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_block_body_block_100,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Body: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_block_body_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Body: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_block_body_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Block Body: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_block_body_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Receipts: block number 7000000 {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_receipts_block_7000000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Receipts: block number 15600000 (post-merge) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_receipts_block_15600000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
-
-            // Test find content Header With Proof
-            test.run(
-                TwoClientTestSpec {
-                    name: format!("FindContent Receipts: block number 17510000 (post-shanghai) {} --> {}", client_a.name, client_b.name),
-                    description: "".to_string(),
-                    always_run: false,
-                    run: test_find_content_receipts_block_17510000,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
-                }
-            ).await;
+            for ProcessedContent { content_type, block_number, test_data } in process_content(content.clone()) {
+                test.run(
+                    NClientTestSpec {
+                        name: format!("FindContent {}: block number {}{} {} --> {}", content_type, block_number, get_flair(block_number), client_a.name, client_b.name),
+                        description: "".to_string(),
+                        always_run: false,
+                        run: test_find_content_x,
+                        environment: None,
+                        test_data: Some(test_data),
+                        clients: vec![client_a.clone(), client_b.clone()],
+                    }
+                ).await;
+            }
 
             // Test gossiping a collection of blocks to node B (B will gossip back to A)
             test.run(
-                TwoClientTestSpec {
+                NClientTestSpec {
                     name: format!("GOSSIP blocks from A:{} --> B:{}", client_a.name, client_b.name),
                     description: "".to_string(),
                     always_run: false,
                     run: test_gossip_two_nodes,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
+                    environment: None,
+                    test_data: Some(content.clone().into_iter().map(content_pair_to_string_pair).collect()),
+                    clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
         }
@@ -602,209 +291,22 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_offer_header_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_header_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_header_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_header_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_header_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_block_body_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[1].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[1].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_block_body_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[3].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[3].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_block_body_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[5].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[5].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_block_body_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[8].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[8].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_block_body_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[11].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[11].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_receipts_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[6].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[6].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_receipts_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[9].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[9].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_receipts_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[12].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[12].get("content_value").unwrap().clone()).unwrap();
-        test_offer_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    async fn test_offer_x<'a>(client_a: Client, client_b: Client, target_content: (HistoryContentKey, HistoryContentValue), optional_content: Option<(HistoryContentKey, HistoryContentValue)>) {
-        if let Some((optional_key, optional_value)) = optional_content {
+    async fn test_offer_x<'a>(clients: Vec<Client>, test_data: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+        let test_data = match test_data {
+            Some(test_data) => test_data,
+            None => panic!("Expected test data non was provided"),
+        };
+        if let Some((optional_key, optional_value)) = test_data.get(1) {
+            let optional_key: HistoryContentKey =
+                serde_json::from_value(json!(optional_key)).unwrap();
+            let optional_value: HistoryContentValue =
+                serde_json::from_value(json!(optional_value)).unwrap();
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for recursive find content");
@@ -814,8 +316,11 @@ dyn_async! {
                 }
             }
         }
-
-        let (target_key, target_value) = target_content;
+        let (target_key, target_value) = test_data.get(0).expect("Target content is required for this test");
+        let target_key: HistoryContentKey =
+            serde_json::from_value(json!(target_key)).unwrap();
+        let target_value: HistoryContentValue =
+            serde_json::from_value(json!(target_value)).unwrap();
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for recursive find content");
@@ -921,223 +426,23 @@ dyn_async! {
 }
 
 dyn_async! {
-    // test that a node will return a header via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_header_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_header_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_header_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_header_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_header_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_block_body_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[1].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[1].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_block_body_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[3].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[3].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_block_body_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[5].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[5].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_block_body_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[8].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[8].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_block_body_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[11].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[11].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_receipts_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[6].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[6].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_receipts_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[9].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[9].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via RECURSIVEFINDCONTENT that is stored locally
-    async fn test_recursive_find_content_receipts_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[12].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[12].get("content_value").unwrap().clone()).unwrap();
-        test_recursive_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
     // test that a node will return a content via RECURSIVEFINDCONTENT template that it has stored locally
-    async fn test_recursive_find_content_x<'a>(client_a: Client, client_b: Client, target_content: (HistoryContentKey, HistoryContentValue), optional_content: Option<(HistoryContentKey, HistoryContentValue)>) {
-        if let Some((optional_key, optional_value)) = optional_content {
+    async fn test_recursive_find_content_x<'a>(clients: Vec<Client>, test_data: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+        let test_data = match test_data {
+            Some(test_data) => test_data,
+            None => panic!("Expected test data non was provided"),
+        };
+        if let Some((optional_key, optional_value)) = test_data.get(1) {
+            let optional_key: HistoryContentKey =
+                serde_json::from_value(json!(optional_key)).unwrap();
+            let optional_value: HistoryContentValue =
+                serde_json::from_value(json!(optional_value)).unwrap();
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for recursive find content");
@@ -1148,7 +453,11 @@ dyn_async! {
             }
         }
 
-        let (target_key, target_value) = target_content;
+        let (target_key, target_value) = test_data.get(0).expect("Target content is required for this test");
+        let target_key: HistoryContentKey =
+            serde_json::from_value(json!(target_key)).unwrap();
+        let target_value: HistoryContentValue =
+            serde_json::from_value(json!(target_value)).unwrap();
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for recursive find content");
@@ -1202,223 +511,23 @@ dyn_async! {
 }
 
 dyn_async! {
-    // test that a node will return a header via FINDCONTENT that is stored locally
-    async fn test_find_content_header_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via FINDCONTENT that is stored locally
-    async fn test_find_content_header_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via FINDCONTENT that is stored locally
-    async fn test_find_content_header_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via FINDCONTENT that is stored locally
-    async fn test_find_content_header_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a header via FINDCONTENT that is stored locally
-    async fn test_find_content_header_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (header_key, header_value), None).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via FINDCONTENT that is stored locally
-    async fn test_find_content_block_body_block_1<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[0].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[0].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[1].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[1].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via FINDCONTENT that is stored locally
-    async fn test_find_content_block_body_block_100<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[2].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[2].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[3].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[3].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via FINDCONTENT that is stored locally
-    async fn test_find_content_block_body_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[5].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[5].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via FINDCONTENT that is stored locally
-    async fn test_find_content_block_body_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[8].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[8].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a block body via FINDCONTENT that is stored locally
-    async fn test_find_content_block_body_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[11].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[11].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via FINDCONTENT that is stored locally
-    async fn test_find_content_receipts_block_7000000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[4].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[4].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[6].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[6].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via FINDCONTENT that is stored locally
-    async fn test_find_content_receipts_block_15600000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[7].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[7].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[9].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[9].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
-    // test that a node will return a receipts via FINDCONTENT that is stored locally
-    async fn test_find_content_receipts_block_17510000<'a> (client_a: Client, client_b: Client) {
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-        let header_key: HistoryContentKey =
-            serde_yaml::from_value(values[10].get("content_key").unwrap().clone()).unwrap();
-        let header_value: HistoryContentValue =
-            serde_yaml::from_value(values[10].get("content_value").unwrap().clone()).unwrap();
-        let content_key: HistoryContentKey =
-            serde_yaml::from_value(values[12].get("content_key").unwrap().clone()).unwrap();
-        let content_value: HistoryContentValue =
-            serde_yaml::from_value(values[12].get("content_value").unwrap().clone()).unwrap();
-        test_find_content_x(client_a, client_b, (content_key, content_value), Some((header_key, header_value))).await;
-    }
-}
-
-dyn_async! {
     // test that a node will return a x content via FINDCONTENT that it has stored locally
-    async fn test_find_content_x<'a> (client_a: Client, client_b: Client, target_content: (HistoryContentKey, HistoryContentValue), optional_content: Option<(HistoryContentKey, HistoryContentValue)>) {
-        if let Some((optional_key, optional_value)) = optional_content {
+    async fn test_find_content_x<'a> (clients: Vec<Client>, test_data: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+        let test_data = match test_data {
+            Some(test_data) => test_data,
+            None => panic!("Expected test data non was provided"),
+        };
+        if let Some((optional_key, optional_value)) = test_data.get(1) {
+            let optional_key: HistoryContentKey =
+                serde_json::from_value(json!(optional_key)).unwrap();
+            let optional_value: HistoryContentValue =
+                serde_json::from_value(json!(optional_value)).unwrap();
             match client_b.rpc.store(optional_key, optional_value).await {
                 Ok(result) => if !result {
                     panic!("Unable to store optional content for find content");
@@ -1429,7 +538,11 @@ dyn_async! {
             }
         }
 
-        let (target_key, target_value) = target_content;
+        let (target_key, target_value) = test_data.get(0).expect("Target content is required for this test");
+        let target_key: HistoryContentKey =
+            serde_json::from_value(json!(target_key)).unwrap();
+        let target_value: HistoryContentValue =
+            serde_json::from_value(json!(target_value)).unwrap();
         match client_b.rpc.store(target_key.clone(), target_value.clone()).await {
             Ok(result) => if !result {
                 panic!("Error storing target content for find content");
@@ -1475,7 +588,17 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_gossip_two_nodes<'a> (client_a: Client, client_b: Client) {
+    async fn test_gossip_two_nodes<'a> (clients: Vec<Client>, test_data: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+        let test_data = match test_data {
+            Some(test_data) => test_data,
+            None => panic!("Expected test data non was provided"),
+        };
         // connect clients
         let client_b_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
@@ -1492,15 +615,11 @@ dyn_async! {
         }
 
         // With default node settings nodes should be storing all content
-        let values = std::fs::read_to_string("./test-data/test_data_collection_of_forks_blocks.yaml")
-            .expect("cannot find test asset");
-        let values: Value = serde_yaml::from_str(&values).unwrap();
-
-        for value in values.as_sequence().unwrap() {
+        for (content_key, content_value) in test_data.clone() {
             let content_key: HistoryContentKey =
-                serde_yaml::from_value(value.get("content_key").unwrap().clone()).unwrap();
+                serde_json::from_value(json!(content_key)).unwrap();
             let content_value: HistoryContentValue =
-                serde_yaml::from_value(value.get("content_value").unwrap().clone()).unwrap();
+                serde_json::from_value(json!(content_value)).unwrap();
 
             match client_a.rpc.gossip(content_key.clone(), content_value.clone()).await {
                 Ok(nodes_gossiped_to) => {
@@ -1529,11 +648,11 @@ dyn_async! {
             "17510000 (post-shanghai) header", "17510000 (post-shanghai) block body", "17510000 (post-shanghai) receipt"];
 
         let mut result = vec![];
-        for (index, value) in values.as_sequence().unwrap().iter().enumerate() {
+        for (index, (content_key, content_value)) in test_data.into_iter().enumerate() {
             let content_key: HistoryContentKey =
-                serde_yaml::from_value(value.get("content_key").unwrap().clone()).unwrap();
+                serde_json::from_value(json!(content_key)).unwrap();
             let content_value: HistoryContentValue =
-                serde_yaml::from_value(value.get("content_value").unwrap().clone()).unwrap();
+                serde_json::from_value(json!(content_value)).unwrap();
 
             match client_b.rpc.local_content(content_key.clone()).await {
                 Ok(possible_content) => {

--- a/simulators/portal-mesh/src/main.rs
+++ b/simulators/portal-mesh/src/main.rs
@@ -7,11 +7,15 @@ use ethportal_api::{
 use hivesim::{dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec};
 use itertools::Itertools;
 use serde_json::json;
+use std::collections::HashMap;
 
 // Header with proof for block number 14764013
 const HEADER_WITH_PROOF_KEY: &str =
     "0x00720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c";
 const HEADER_WITH_PROOF_VALUE: &str = "0x080000002d020000f90222a02c58e3212c085178dbb1277e2f3c24b3f451267a75a234945c1581af639f4a7aa058a694212e0416353a4d3865ccf475496b55af3a3d3b002057000741af9731919400192fb10df37c9fb26829eb2cc623cd1bf599e8a067a9fb631f4579f9015ef3c6f1f3830dfa2dc08afe156f750e90022134b9ebf6a018a2978fc62cd1a23e90de920af68c0c3af3330327927cda4c005faccefb5ce7a0168a3827607627e781941dc777737fc4b6beb69a8b139240b881992b35b854eab9010000200000400000001000400080080000000000010004010001000008000000002000110000000000000090020001110402008000080208040010000000a8000000000000000000210822000900205020000000000160020020000400800040000000000042080000000400004008084020001000001004004000001000000000000001000000110000040000010200844040048101000008002000404810082002800000108020000200408008000100000000000000002020000b00010080600902000200000050000400000000000000400000002002101000000a00002000003420000800400000020100002000000000000000c00040000001000000100187327bd7ad3116ce83e147ed8401c9c36483140db184627d9afa9a457468657265756d50504c4e532f326d696e6572735f55534133a0f1a32e24eb62f01ec3f2b3b5893f7be9062fbf5482bc0d490a54352240350e26882087fbb243327696851aae1651b6010cc53ffa2df1bae1550a0000000000000000000000000000000000000000000063d45d0a2242d35484f289108b3c80cccf943005db0db6c67ffea4c4a47fd529f64d74fa6068a3fd89a2c0d9938c3a751c4706d0b0e8f99dec6b517cf12809cb413795c8c678b3171303ddce2fa1a91af6a0961b9db72750d4d5ea7d5103d8d25f23f522d9af4c13fe8ac7a7d9d64bb08d980281eea5298b93cb1085fedc19d4c60afdd52d116cfad030cf4223e50afa8031154a2263c76eb08b96b5b8fdf5e5c30825d5c918eefb89daaf0e8573f20643614d9843a1817b6186074e4e53b22cf49046d977c901ec00aef1555fa89468adc2a51a081f186c995153d1cba0f2887d585212d68be4b958d309fbe611abe98a9bfc3f4b7a7b72bb881b888d89a04ecfe08b1c1a48554a48328646e4f864fe722f12d850f0be29e3829d1f94b34083032a9b6f43abd559785c996229f8e022d4cd6dcde4aafcce6445fe8743e1fcbe8672a99f9d9e3a5ca10c01f3751d69fbd22197f0680bc1529151130b22759bf185f4dbce357f46eb9cc8e21ea78f49b298eea2756d761fe23de8bea0d2e15aed136d689f6d252c54ebadc3e46b84a397b681edf7ec63522b9a298301084d019d0020000000000000000000000000000000000000000000000000000000000000";
+
+// private key hive environment variable
+const PRIVATE_KEY_ENVIRONMENT_VARIABLE: &str = "HIVE_CLIENT_PRIVATE_KEY";
 
 #[tokio::main]
 async fn main() {
@@ -65,7 +69,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    private_keys: Some(vec![None, Some(private_key_2.clone()), Some(private_key_1.clone())]),
+                    environment: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())]))]),
+                    test_data: None,
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -77,7 +82,8 @@ dyn_async! {
                     description: "".to_string(),
                     always_run: false,
                     run: test_find_content_two_jumps,
-                    private_keys: Some(vec![None, Some(private_key_1.clone()), Some(private_key_2.clone())]),
+                    environment: Some(vec![None, Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_1.clone())])), Some(HashMap::from([(PRIVATE_KEY_ENVIRONMENT_VARIABLE.to_string(), private_key_2.clone())]))]),
+                    test_data: None,
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -88,7 +94,8 @@ dyn_async! {
                     description: "find nodes: distance of client A expect seeded enr returned".to_string(),
                     always_run: false,
                     run: test_find_nodes_distance_of_client_c,
-                    private_keys: None,
+                    environment: None,
+                    test_data: None,
                     clients: vec![client_a.clone(), client_b.clone(), client_c.clone()],
                 }
             ).await;
@@ -97,7 +104,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>) {
+    async fn test_find_content_two_jumps<'a> (clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {
@@ -192,7 +199,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>) {
+    async fn test_find_nodes_distance_of_client_c<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let (client_a, client_b, client_c) = match clients.iter().collect_tuple() {
             Some((client_a, client_b, client_c)) => (client_a, client_b, client_c),
             None => {


### PR DESCRIPTION
We now properly support sending enironment variables per client instead of just private keys.

I also made it so tests will be auto generated from a test file of content.

Order of the test file matters so it should be
1. Header
2. (optional bb or receipt)
3. (optional bb or receipt)

The implementation should be flexibile enough so different schemes can be done but this is the scheme for history content.