### PR TITLE
fix: configure trin to run on port 9009

### DIFF
--- a/clients/trin/Dockerfile
+++ b/clients/trin/Dockerfile
@@ -11,6 +11,6 @@ RUN chmod +x /trin_version.sh
 RUN /trin_version.sh > /version.txt
 
 # Export the usual networking ports to allow outside access to the node
-EXPOSE 8545 9000/udp
+EXPOSE 8545 9009/udp
 
 ENTRYPOINT ["/trin.sh"]

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -7,7 +7,7 @@ IP_ADDR=$(hostname -i | awk '{print $1}')
 
 # if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
 if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none
+  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none
 else
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9000 --bootnodes none --unsafe-private-key 0x${HIVE_CLIENT_PRIVATE_KEY}
+  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none --unsafe-private-key 0x${HIVE_CLIENT_PRIVATE_KEY}
 fi


### PR DESCRIPTION
trin now defaults to 9009 (default was 9000 previously)

Downstream bug in hive triggered by this change: https://github.com/ethereum/trin/pull/1002