### PR TITLE
fix: make gossip portal-interop test auto generate comments for errors

### DIFF
--- a/simulators/history/portal-interop/src/main.rs
+++ b/simulators/history/portal-interop/src/main.rs
@@ -641,7 +641,7 @@ dyn_async! {
             }
         }
 
-        // wait content_vec.len() seconds for data to propagate, giving more time if more items are propagating
+        // wait test_data.len() seconds for data to propagate, giving more time if more items are propagating
         tokio::time::sleep(Duration::from_secs(test_data.len() as u64)).await;
 
         // process raw test data to generate content details for error output


### PR DESCRIPTION
Since we can dynamically add tests over time we also need a way of generating the error comments dynamically