### PR TITLE
feat: update rpc_compat to use NClientTestSpec

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -4,10 +4,11 @@
 set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
+FLAGS=""
 
-# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
-  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug"
-else
-  fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" --netkey-unsafe=0x${HIVE_CLIENT_PRIVATE_KEY}
+if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
+    FLAGS="$FLAGS --netkey-unsafe=0x$HIVE_CLIENT_PRIVATE_KEY"
 fi
+
+# Fluffy runs all networks by default, so we can not configure to run networks individually
+fluffy --rpc --rpc-address="0.0.0.0" --nat:extip:"$IP_ADDR" --network=none --log-level="debug" $FLAGS

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -4,10 +4,16 @@
 set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
+FLAGS=""
 
-# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none
-else
-  RUST_LOG=debug TRIN_INFURA_PROJECT_ID="your-key-here" trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none --unsafe-private-key 0x${HIVE_CLIENT_PRIVATE_KEY}
+if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
+    FLAGS="$FLAGS --unsafe-private-key 0x$HIVE_CLIENT_PRIVATE_KEY"
 fi
+
+if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
+    FLAGS="$FLAGS --networks $HIVE_PORTAL_NETWORKS_SELECTED"
+else
+    FLAGS="$FLAGS --networks history"
+fi
+
+RUST_LOG=debug trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none $FLAGS

--- a/clients/ultralight/ultralight.sh
+++ b/clients/ultralight/ultralight.sh
@@ -4,10 +4,16 @@
 set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
+FLAGS=""
 
-# if HIVE_CLIENT_PRIVATE_KEY isn't set or doesn't exist do y, else do z
-if [ -z ${HIVE_CLIENT_PRIVATE_KEY+x} ]; then
-  DEBUG=* node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545
-else
-  DEBUG=* node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 --pk=0x1a2408021220${HIVE_CLIENT_PRIVATE_KEY}
+if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
+    FLAGS="$FLAGS --pk=0x1a2408021220$HIVE_CLIENT_PRIVATE_KEY"
 fi
+
+if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
+    FLAGS="$FLAGS --networks=$HIVE_PORTAL_NETWORKS_SELECTED"
+else
+    FLAGS="$FLAGS --networks=history"
+fi
+
+DEBUG=* node /ultralight/packages/cli/dist/index.js --bindAddress="$IP_ADDR:9000" --dataDir="./data" --rpcPort=8545 $FLAGS

--- a/simulators/history/rpc-compat/src/main.rs
+++ b/simulators/history/rpc-compat/src/main.rs
@@ -14,7 +14,7 @@ const CONTENT_VALUE: &str = "0x080000002d020000f90222a02c58e3212c085178dbb1277e2
 async fn main() {
     tracing_subscriber::fmt::init();
     let mut suite = Suite {
-        name: "rpc-compat".to_string(),
+        name: "history-rpc-compat".to_string(),
         description: "The RPC-compatibility test suite runs a set of RPC related tests against a
         running node. It tests client implementations of the JSON-RPC API for
         conformance with the portal network API specification."
@@ -71,7 +71,7 @@ dyn_async! {
                     name: "portal_historyLocalContent Expect ContentAbsent".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_local_content_expect_content_absent,
+                    run: test_local_content_expect_content_absent,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -83,7 +83,7 @@ dyn_async! {
                     name: "portal_historyStore".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_store,
+                    run: test_store,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -95,7 +95,7 @@ dyn_async! {
                     name: "portal_historyLocalContent Expect ContentPresent".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_local_content_expect_content_present,
+                    run: test_local_content_expect_content_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -107,7 +107,7 @@ dyn_async! {
                     name: "portal_historyAddEnr Expect true".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_add_enr_expect_true,
+                    run: test_add_enr_expect_true,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -119,7 +119,7 @@ dyn_async! {
                     name: "portal_historyGetEnr None Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_get_enr_non_present,
+                    run: test_get_enr_non_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -131,7 +131,7 @@ dyn_async! {
                     name: "portal_historyGetEnr ENR Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_get_enr_enr_present,
+                    run: test_get_enr_enr_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -143,7 +143,7 @@ dyn_async! {
                     name: "portal_historyGetEnr Local Enr".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_get_enr_local_enr,
+                    run: test_get_enr_local_enr,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -155,7 +155,7 @@ dyn_async! {
                     name: "portal_historyDeleteEnr None Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_delete_enr_non_present,
+                    run: test_delete_enr_non_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -167,7 +167,7 @@ dyn_async! {
                     name: "portal_historyDeleteEnr ENR Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_delete_enr_enr_present,
+                    run: test_delete_enr_enr_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -179,7 +179,7 @@ dyn_async! {
                     name: "portal_historyLookupEnr None Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_lookup_enr_non_present,
+                    run: test_lookup_enr_non_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -191,7 +191,7 @@ dyn_async! {
                     name: "portal_historyLookupEnr ENR Found".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_lookup_enr_enr_present,
+                    run: test_lookup_enr_enr_present,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -203,7 +203,7 @@ dyn_async! {
                     name: "portal_historyLookupEnr Local Enr".to_string(),
                     description: "".to_string(),
                     always_run: false,
-                    run: test_history_lookup_enr_local_enr,
+                    run: test_lookup_enr_local_enr,
                     environments: None,
                     test_data: None,
                     clients: vec![client.clone()],
@@ -243,7 +243,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -277,7 +277,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_store<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_store<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -313,7 +313,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -366,7 +366,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -385,7 +385,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -401,7 +401,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -429,7 +429,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -460,7 +460,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -479,7 +479,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -524,7 +524,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -540,7 +540,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {
@@ -571,7 +571,7 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+    async fn test_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
         let client = match clients.into_iter().next() {
             Some((client)) => client,
             None => {

--- a/simulators/history/rpc-compat/src/main.rs
+++ b/simulators/history/rpc-compat/src/main.rs
@@ -3,7 +3,7 @@ use ethportal_api::types::portal::ContentInfo;
 use ethportal_api::Discv5ApiClient;
 use ethportal_api::PossibleHistoryContentValue::{ContentAbsent, ContentPresent};
 use ethportal_api::{HistoryContentKey, HistoryNetworkApiClient};
-use hivesim::{dyn_async, Client, ClientTestSpec, Simulation, Suite, Test, TestSpec};
+use hivesim::{dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec};
 use serde_json::json;
 
 // Header with proof for block number 14764013
@@ -49,125 +49,192 @@ async fn run_suite(host: Simulation, suite: Suite) {
 
 dyn_async! {
     async fn run_all_client_tests<'a> (test: &'a mut Test, _client: Option<Client>) {
-        test.run(ClientTestSpec {
-            name: "discv5_nodeInfo".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_node_info,
-        })
-        .await;
+        // Get all available portal clients
+        let clients = test.sim.client_types().await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyLocalContent Expect ContentAbsent".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_local_content_expect_content_absent,
-        })
-        .await;
+        // Test single type of client
+        for client in &clients {
+            test.run(
+                NClientTestSpec {
+                    name: "discv5_nodeInfo".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_node_info,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyStore".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_store,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyLocalContent Expect ContentAbsent".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_local_content_expect_content_absent,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyLocalContent Expect ContentPresent".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_local_content_expect_content_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyStore".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_store,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyAddEnr Expect true".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_add_enr_expect_true,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyLocalContent Expect ContentPresent".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_local_content_expect_content_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyGetEnr None Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_get_enr_non_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyAddEnr Expect true".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_add_enr_expect_true,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyGetEnr ENR Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_get_enr_enr_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyGetEnr None Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_get_enr_non_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyGetEnr Local Enr".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_get_enr_local_enr,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyGetEnr ENR Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_get_enr_enr_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyDeleteEnr None Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_delete_enr_non_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyGetEnr Local Enr".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_get_enr_local_enr,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyDeleteEnr ENR Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_delete_enr_enr_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyDeleteEnr None Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_delete_enr_non_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyLookupEnr None Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_lookup_enr_non_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyDeleteEnr ENR Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_delete_enr_enr_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyLookupEnr ENR Found".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_lookup_enr_enr_present,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyLookupEnr None Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_lookup_enr_non_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyLookupEnr Local Enr".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_history_lookup_enr_local_enr,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyLookupEnr ENR Found".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_lookup_enr_enr_present,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
 
-        test.run(ClientTestSpec {
-            name: "portal_historyRecursiveFindContent Content Absent".to_string(),
-            description: "".to_string(),
-            always_run: false,
-            run: test_recursive_find_content_content_absent,
-        })
-        .await;
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyLookupEnr Local Enr".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_history_lookup_enr_local_enr,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
+
+            test.run(
+                NClientTestSpec {
+                    name: "portal_historyRecursiveFindContent Content Absent".to_string(),
+                    description: "".to_string(),
+                    always_run: false,
+                    run: test_recursive_find_content_content_absent,
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client.clone()],
+                }
+            ).await;
+        }
     }
 }
 
 dyn_async! {
-    async fn test_node_info<'a> (client: Client) {
-       let response = client
-            .rpc
-            .node_info().await;
+    async fn test_node_info<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+
+        let response = Discv5ApiClient::node_info(&client.rpc).await;
 
         if let Err(err) = response {
             panic!("Expected response not received: {err}");
@@ -176,15 +243,19 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_absent<'a>(client: Client) {
+    async fn test_history_local_content_expect_content_absent<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let content_key =
         serde_json::from_value(json!(CONTENT_KEY));
 
         match content_key {
             Ok(content_key) => {
-                let response = client
-                    .rpc
-                    .local_content(content_key).await;
+                let response = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await;
 
                 match response {
                     Ok(response) => {
@@ -206,7 +277,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_store<'a>(client: Client) {
+    async fn test_history_store<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let content_key =
         serde_json::from_value(json!(CONTENT_KEY));
 
@@ -217,9 +294,7 @@ dyn_async! {
             Ok(content_key) => {
                 match content_value {
                     Ok(content_value) => {
-                        let response = client
-                            .rpc
-                            .store(content_key, content_value).await;
+                        let response = HistoryNetworkApiClient::store(&client.rpc, content_key, content_value).await;
 
                         if let Err(err) = response {
                             panic!("{}", &err.to_string());
@@ -238,7 +313,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_local_content_expect_content_present<'a>(client: Client) {
+    async fn test_history_local_content_expect_content_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let content_key: Result<ethportal_api::HistoryContentKey, serde_json::Error> =
         serde_json::from_value(json!(CONTENT_KEY));
 
@@ -251,9 +332,7 @@ dyn_async! {
                 // seed content_key/content_value onto the local node to test local_content expect content present
                 match content_value {
                     Ok(content_value) => {
-                        let response = client
-                            .rpc
-                            .store(content_key.clone(), content_value).await;
+                        let response = HistoryNetworkApiClient::store(&client.rpc, content_key.clone(), content_value).await;
 
                         if let Err(err) = response {
                             panic!("{}", &err.to_string());
@@ -265,9 +344,7 @@ dyn_async! {
                 }
 
                 // Here we are calling local_content RPC to test if the content is present
-                let response = client
-                    .rpc
-                    .local_content(content_key).await;
+                let response = HistoryNetworkApiClient::local_content(&client.rpc, content_key).await;
 
                 match response {
                     Ok(response) => {
@@ -289,7 +366,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_add_enr_expect_true<'a>(client: Client) {
+    async fn test_history_add_enr_expect_true<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::add_enr(&client.rpc, enr).await {
             Ok(response) => match response {
@@ -302,7 +385,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_non_present<'a>(client: Client) {
+    async fn test_history_get_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
 
         if (HistoryNetworkApiClient::get_enr(&client.rpc, enr.node_id()).await).is_ok() {
@@ -312,9 +401,15 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_local_enr<'a>(client: Client) {
+    async fn test_history_get_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         // get our local enr from NodeInfo
-        let target_enr = match client.rpc.node_info().await {
+        let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
                 panic!("Error getting node info: {err:?}");
@@ -334,7 +429,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_get_enr_enr_present<'a>(client: Client) {
+    async fn test_history_get_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
@@ -359,7 +460,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_non_present<'a>(client: Client) {
+    async fn test_history_delete_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
         match HistoryNetworkApiClient::delete_enr(&client.rpc, enr.node_id()).await {
             Ok(response) => match response {
@@ -372,7 +479,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_delete_enr_enr_present<'a>(client: Client) {
+    async fn test_history_delete_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
@@ -411,7 +524,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_non_present<'a>(client: Client) {
+    async fn test_history_lookup_enr_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
 
         if (HistoryNetworkApiClient::lookup_enr(&client.rpc, enr.node_id()).await).is_ok() {
@@ -421,7 +540,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_enr_present<'a>(client: Client) {
+    async fn test_history_lookup_enr_enr_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let (_, enr) = generate_random_remote_enr();
 
         // seed enr into routing table
@@ -446,9 +571,15 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_history_lookup_enr_local_enr<'a>(client: Client) {
+    async fn test_history_lookup_enr_local_enr<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         // get our local enr from NodeInfo
-        let target_enr = match client.rpc.node_info().await {
+        let target_enr = match Discv5ApiClient::node_info(&client.rpc).await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
                 panic!("Error getting node info: {err:?}");
@@ -469,10 +600,16 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will return a AbsentContent via RecursiveFindContent when the data doesn't exist
-    async fn test_recursive_find_content_content_absent<'a> (client: Client) {
+    async fn test_recursive_find_content_content_absent<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let client = match clients.into_iter().next() {
+            Some((client)) => client,
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(CONTENT_KEY)).unwrap();
 
-        match client.rpc.recursive_find_content(header_with_proof_key).await {
+        match HistoryNetworkApiClient::recursive_find_content(&client.rpc, header_with_proof_key).await {
             Ok(result) => {
                 match result {
                     ContentInfo::Content{ content: ethportal_api::PossibleHistoryContentValue::ContentAbsent, utp_transfer } => {


### PR DESCRIPTION
These PR's should be reviewed/merged in this order
1. https://github.com/ethereum/portal-hive/pull/118
2. https://github.com/ethereum/portal-hive/pull/124
3. https://github.com/ethereum/portal-hive/pull/125
4. https://github.com/ethereum/portal-hive/pull/126
5. https://github.com/ethereum/portal-hive/pull/127

PR 3 of the refactor to support multiple networks for portal-hive tests
Updating rpc_compat to NClientTestSpec as beacon/rpc_compac will require environment support to activate the beacon network