### PR TITLE
refactor: only use NClientTestSpec remove ClientTestSpec and TwoClientTestSpec

### DIFF
--- a/hivesim-rs/src/lib.rs
+++ b/hivesim-rs/src/lib.rs
@@ -8,7 +8,5 @@ pub mod types;
 pub mod utils;
 
 pub use simulation::Simulation;
-pub use testapi::{
-    Client, ClientTestSpec, NClientTestSpec, Suite, Test, TestSpec, TwoClientTestSpec,
-};
+pub use testapi::{Client, NClientTestSpec, Suite, Test, TestSpec};
 pub use testmatch::TestMatcher;

--- a/simulators/history/portal-interop/src/main.rs
+++ b/simulators/history/portal-interop/src/main.rs
@@ -11,9 +11,7 @@ use ethportal_api::{
     ContentValue, Discv5ApiClient, HistoryContentKey, HistoryContentValue, HistoryNetworkApiClient,
     OverlayContentKey, PossibleHistoryContentValue,
 };
-use hivesim::{
-    dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec, TwoClientTestSpec,
-};
+use hivesim::{dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec};
 use itertools::Itertools;
 use serde_json::json;
 use serde_yaml::Value;
@@ -209,35 +207,38 @@ dyn_async! {
             }
 
             // Test portal history ping
-            test.run(TwoClientTestSpec {
+            test.run(NClientTestSpec {
                     name: format!("PING {} --> {}", client_a.name, client_b.name),
                     description: "".to_string(),
                     always_run: false,
                     run: test_ping,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
 
             // Test find content non-present
-            test.run(TwoClientTestSpec {
+            test.run(NClientTestSpec {
                     name: format!("FIND_CONTENT non present {} --> {}", client_a.name, client_b.name),
                     description: "find content: calls find content that doesn't exist".to_string(),
                     always_run: false,
                     run: test_find_content_non_present,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
 
             // Test find nodes distance zero
-            test.run(TwoClientTestSpec {
+            test.run(NClientTestSpec {
                     name: format!("FIND_NODES Distance 0 {} --> {}", client_a.name, client_b.name),
                     description: "find nodes: distance zero expect called nodes enr".to_string(),
                     always_run: false,
                     run: test_find_nodes_zero_distance,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
 
@@ -259,7 +260,13 @@ dyn_async! {
 
 dyn_async! {
     // test that a node will not return content via FINDCONTENT.
-    async fn test_find_content_non_present<'a> (client_a: Client, client_b: Client) {
+    async fn test_find_content_non_present<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let header_with_proof_key: HistoryContentKey = serde_json::from_value(json!(HEADER_WITH_PROOF_KEY)).unwrap();
 
         let target_enr = match client_b.rpc.node_info().await {
@@ -366,7 +373,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_ping<'a>(client_a: Client, client_b: Client) {
+    async fn test_ping<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {
@@ -401,7 +414,13 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_find_nodes_zero_distance<'a>(client_a: Client, client_b: Client) {
+    async fn test_find_nodes_zero_distance<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
         let target_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {

--- a/simulators/history/trin-bridge/src/main.rs
+++ b/simulators/history/trin-bridge/src/main.rs
@@ -11,7 +11,7 @@ use ethportal_api::HistoryContentValue;
 use ethportal_api::PossibleHistoryContentValue;
 use ethportal_api::{Discv5ApiClient, HistoryNetworkApiClient};
 use hivesim::types::ClientDefinition;
-use hivesim::{dyn_async, Client, Simulation, Suite, Test, TestSpec, TwoClientTestSpec};
+use hivesim::{dyn_async, Client, NClientTestSpec, Simulation, Suite, Test, TestSpec};
 use itertools::Itertools;
 use serde_yaml::Value;
 use std::collections::HashMap;
@@ -116,13 +116,14 @@ dyn_async! {
         // Iterate over all possible pairings of clients and run the tests (including self-pairings)
         for (client_a, client_b) in clients.iter().cartesian_product(clients.iter()) {
             test.run(
-                TwoClientTestSpec {
+                NClientTestSpec {
                     name: format!("Bridge test. A:{} --> B:{}", client_a.name, client_b.name),
                     description: "".to_string(),
                     always_run: false,
                     run: test_bridge,
-                    client_a: client_a.clone(),
-                    client_b: client_b.clone(),
+                    environments: None,
+                    test_data: None,
+                    clients: vec![client_a.clone(), client_b.clone()],
                 }
             ).await;
         }
@@ -130,7 +131,14 @@ dyn_async! {
 }
 
 dyn_async! {
-    async fn test_bridge<'a> (client_a: Client, client_b: Client) {
+    async fn test_bridge<'a>(clients: Vec<Client>, _: Option<Vec<(String, String)>>) {
+        let (client_a, client_b) = match clients.iter().collect_tuple() {
+            Some((client_a, client_b)) => (client_a, client_b),
+            None => {
+                panic!("Unable to get expected amount of clients from NClientTestSpec");
+            }
+        };
+
         let client_b_enr = match client_b.rpc.node_info().await {
             Ok(node_info) => node_info.enr,
             Err(err) => {


### PR DESCRIPTION
In this PR I remove ClientTestSpec and TwoClientTestSpec completely.
Some reasons for this
- I don't want to maintain 3 different code paths which are almost identical
- NClientTestSpec can be used to write all tests, but ClientTestSpec/TwoClientTestSpec can't
- I want to be able to implement new features once not 3 times
- This increases code uniformity making reviews easier

Also NClientTestSpec has features implemented which ClientTestSpec/TwoClientTestSpec don't. Implementing the same features 3 times in redundent and error prone. In the current state ClientTestSpec/TwoClientTestSpec can't be used on other networks then history, and there are also other features they don't support.

Expessially when we move from portal-hive to hive. Changing hivesim-rs will not be as easy.


I am not sure what to say less code to maintain good. Mo identical functions mo problems - The Notorious B.I.G