### PR TITLE
Enable beacon network for fluffy portal-hive tests

### DIFF
--- a/clients/fluffy/fluffy.sh
+++ b/clients/fluffy/fluffy.sh
@@ -4,7 +4,9 @@
 set -e
 
 IP_ADDR=$(hostname -i | awk '{print $1}')
-FLAGS=""
+# Providing atrusted block root is required currently to enable the beacon network.
+# It can be a made up value for now as tests are not doing any sync.
+FLAGS="--trusted-block-root:0x0000000000000000000000000000000000000000000000000000000000000000"
 
 if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
     FLAGS="$FLAGS --netkey-unsafe=0x$HIVE_CLIENT_PRIVATE_KEY"


### PR DESCRIPTION
Fluffy will get some better support for enabling Portal networks. But for now this is the way to enable Portal beacon network.