### PR TITLE
feat: add TestData enum to allow for future new datatypes

### DIFF
--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -200,7 +200,7 @@ pub enum TestData {
     /// A list of tupel's containing content key/value pairs
     ContentList(Vec<(String, String)>),
     /// A list of tupel's containing a content key, offer value, and return value
-    StateContentList((String, String, String)),
+    StateContentList(Vec<(String, String, String)>),
 }
 
 #[derive(Clone)]

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -1,4 +1,4 @@
-use crate::types::{ClientDefinition, SuiteID, TestID, TestResult};
+use crate::types::{ClientDefinition, SuiteID, TestData, TestID, TestResult};
 use crate::Simulation;
 use ::std::{boxed::Box, future::Future, pin::Pin};
 use async_trait::async_trait;
@@ -193,14 +193,6 @@ pub async fn run_test(
     );
 
     host.end_test(suite_id, test_id, test_result).await;
-}
-
-#[derive(Clone, Debug)]
-pub enum TestData {
-    /// A list of tupel's containing content key/value pairs
-    ContentList(Vec<(String, String)>),
-    /// A list of tupel's containing a content key, offer value, and return value
-    StateContentList(Vec<(String, String, String)>),
 }
 
 #[derive(Clone)]

--- a/hivesim-rs/src/testapi.rs
+++ b/hivesim-rs/src/testapi.rs
@@ -23,7 +23,7 @@ pub type AsyncTestFunc = fn(
 
 pub type AsyncNClientsTestFunc = fn(
     Vec<Client>,
-    Option<Vec<(String, String)>>,
+    Option<TestData>,
 ) -> Pin<
     Box<
         dyn Future<Output = ()> // future API / pollable
@@ -195,6 +195,14 @@ pub async fn run_test(
     host.end_test(suite_id, test_id, test_result).await;
 }
 
+#[derive(Clone, Debug)]
+pub enum TestData {
+    /// A list of tupel's containing content key/value pairs
+    ContentList(Vec<(String, String)>),
+    /// A list of tupel's containing a content key, offer value, and return value
+    StateContentList((String, String, String)),
+}
+
 #[derive(Clone)]
 pub struct NClientTestSpec {
     /// These fields are displayed in the UI. Be sure to add
@@ -211,7 +219,7 @@ pub struct NClientTestSpec {
     /// The environments must be in the same order as the `clients`
     pub environments: Option<Vec<Option<HashMap<String, String>>>>,
     /// test data which can be passed to the test
-    pub test_data: Option<Vec<(String, String)>>,
+    pub test_data: Option<TestData>,
     pub clients: Vec<ClientDefinition>,
 }
 
@@ -243,7 +251,7 @@ async fn run_n_client_test(
     host: Simulation,
     test: TestRun,
     environments: Option<Vec<Option<HashMap<String, String>>>>,
-    test_data: Option<Vec<(String, String)>>,
+    test_data: Option<TestData>,
     clients: Vec<ClientDefinition>,
     func: AsyncNClientsTestFunc,
 ) {

--- a/hivesim-rs/src/types.rs
+++ b/hivesim-rs/src/types.rs
@@ -36,3 +36,24 @@ pub struct TestResult {
     pub pass: bool,
     pub details: String,
 }
+
+#[derive(Clone, Debug)]
+pub struct ContentKeyValue {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ContentKeyOfferLookupValues {
+    pub key: String,
+    pub offer_value: String,
+    pub lookup_value: String,
+}
+
+#[derive(Clone, Debug)]
+pub enum TestData {
+    /// A list of tuple's containing content key/value pairs
+    ContentList(Vec<ContentKeyValue>),
+    /// A list of tuple's containing a content key, offer value, and return value
+    StateContentList(Vec<ContentKeyOfferLookupValues>),
+}

--- a/hivesim-rs/src/types.rs
+++ b/hivesim-rs/src/types.rs
@@ -52,8 +52,8 @@ pub struct ContentKeyOfferLookupValues {
 
 #[derive(Clone, Debug)]
 pub enum TestData {
-    /// A list of tuple's containing content key/value pairs
+    /// A list of tuples containing content key/value pairs
     ContentList(Vec<ContentKeyValue>),
-    /// A list of tuple's containing a content key, offer value, and return value
+    /// A list of tuples containing a content key, offer value, and lookup value
     StateContentList(Vec<ContentKeyOfferLookupValues>),
 }


### PR DESCRIPTION
as the title says different networks will have different requirements so making this into an enum means adding future requirements will be very easy to do