### PR TITLE
remove outdated bridge cli arg

### DIFF
--- a/clients/trin-bridge/trin_bridge.sh
+++ b/clients/trin-bridge/trin_bridge.sh
@@ -13,4 +13,4 @@ else
     exit 1
 fi
 
-RUST_LOG=debug portal-bridge --node-count 1 $FLAGS --executable-path ./usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --external-ip $IP_ADDR --epoch-accumulator-path . trin
+RUST_LOG=debug portal-bridge $FLAGS --executable-path ./usr/bin/trin --mode test:/test_data_collection_of_forks_blocks.yaml --external-ip $IP_ADDR --epoch-accumulator-path . trin

--- a/clients/trin/trin.sh
+++ b/clients/trin/trin.sh
@@ -11,9 +11,9 @@ if [ "$HIVE_CLIENT_PRIVATE_KEY" != "" ]; then
 fi
 
 if [ "$HIVE_PORTAL_NETWORKS_SELECTED" != "" ]; then
-    FLAGS="$FLAGS --networks $HIVE_PORTAL_NETWORKS_SELECTED"
+    FLAGS="$FLAGS --portal-subnetworks $HIVE_PORTAL_NETWORKS_SELECTED"
 else
-    FLAGS="$FLAGS --networks history"
+    FLAGS="$FLAGS --portal-subnetworks history"
 fi
 
 RUST_LOG=debug trin --web3-transport http --web3-http-address http://0.0.0.0:8545 --external-address "$IP_ADDR":9009 --bootnodes none $FLAGS


### PR DESCRIPTION
we no longer support the `--node-count` flag in trin bridge, & `---networks` -> `--portal-subnetworks` in trin